### PR TITLE
Adding argument for protocol support to NPN Extension

### DIFF
--- a/tls/handshake_extensions.go
+++ b/tls/handshake_extensions.go
@@ -159,9 +159,11 @@ func (e *ExtendedMasterSecretExtension) Marshal() []byte {
 }
 
 type NextProtocolNegotiationExtension struct {
+	Protocols []string
 }
 
 func (e *NextProtocolNegotiationExtension) WriteToConfig(c *Config) error {
+	c.NextProtos = e.Protocols
 	return nil
 }
 


### PR DESCRIPTION
Simply adding a parameter to the NPN extension so custom client hellos can specify which protocols they will accept when using NPN.