### PR TITLE
Server KEX Algorithm Compatability

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -228,11 +228,24 @@ type signatureAndHash struct {
 // supportedSKXSignatureAlgorithms contains the signature and hash algorithms
 // that the code advertises as supported in a TLS 1.2 ClientHello.
 var supportedSKXSignatureAlgorithms = []signatureAndHash{
+	{signatureRSA, hashSHA512},
+	{signatureECDSA, hashSHA512},
+	{signatureDSA, hashSHA512},
+	{signatureRSA, hashSHA384},
+	{signatureECDSA, hashSHA384},
+	{signatureDSA, hashSHA384},
 	{signatureRSA, hashSHA256},
 	{signatureECDSA, hashSHA256},
+	{signatureDSA, hashSHA256},
+	{signatureRSA, hashSHA224},
+	{signatureECDSA, hashSHA224},
+	{signatureDSA, hashSHA224},
 	{signatureRSA, hashSHA1},
 	{signatureECDSA, hashSHA1},
 	{signatureDSA, hashSHA1},
+	{signatureRSA, hashMD5},
+	{signatureECDSA, hashMD5},
+	{signatureDSA, hashMD5},
 }
 
 var defaultSKXSignatureAlgorithms = []signatureAndHash{


### PR DESCRIPTION
Expand the compatibility of supported Server KEX algorithms to include SHAs 224, 384, and 512 and MD5.