### PR TITLE
Resolve race condition in Server KEX Algorithm fields

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -422,6 +422,10 @@ type Config struct {
 	// supported for ECDHE key exchanges
 	ExplicitCurvePreferences bool
 
+	// If enabled, specifies the signature and hash algorithms to be accepted by
+	// a server, or sent by a client
+	SignatureAndHashes []signatureAndHash
+
 	serverInitOnce sync.Once // guards calling (*Config).serverInit
 
 	// Add all ciphers in CipherSuites to Client Hello even if unimplemented
@@ -726,20 +730,16 @@ func (c *Config) getCertificateForName(name string) *Certificate {
 }
 
 func (c *Config) signatureAndHashesForServer() []signatureAndHash {
-	/*
-		if c != nil && c.SignatureAndHashes != nil {
-			return c.SignatureAndHashes
-		}
-	*/
+	if c != nil && c.SignatureAndHashes != nil {
+		return c.SignatureAndHashes
+	}
 	return supportedClientCertSignatureAlgorithms
 }
 
 func (c *Config) signatureAndHashesForClient() []signatureAndHash {
-	/*
-		if c != nil && c.SignatureAndHashes != nil {
-			return c.SignatureAndHashes
-		}
-	*/
+	if c != nil && c.SignatureAndHashes != nil {
+		return c.SignatureAndHashes
+	}
 	if c.ClientDSAEnabled {
 		return supportedSKXSignatureAlgorithms
 	}

--- a/tls/handshake_extensions.go
+++ b/tls/handshake_extensions.go
@@ -346,8 +346,7 @@ type SignatureAlgorithmExtension struct {
 }
 
 func (e *SignatureAlgorithmExtension) WriteToConfig(c *Config) error {
-	supportedSKXSignatureAlgorithms = e.getStructuredAlgorithms()
-	defaultSKXSignatureAlgorithms = e.getStructuredAlgorithms()
+	c.SignatureAndHashes = e.getStructuredAlgorithms()
 	return nil
 }
 

--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -362,7 +362,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		}
 		if c.vers >= VersionTLS12 {
 			certReq.hasSignatureAndHash = true
-			certReq.signatureAndHashes = supportedClientCertSignatureAlgorithms
+			certReq.signatureAndHashes = c.config.signatureAndHashesForServer()
 		}
 
 		// An empty list of certificateAuthorities signals to


### PR DESCRIPTION
Fixes a race condition that arises when using multiple permitted
server key exchange algorithms in the same process

Depends upon #4 to pass tests.