### PR TITLE
Add SubjectEquals to x509.Certificate

### DIFF
--- a/x509/verify.go
+++ b/x509/verify.go
@@ -170,7 +170,7 @@ nextIntermediate:
 	for _, intermediateNum := range possibleIntermediates {
 		intermediate := opts.Intermediates.certs[intermediateNum]
 		for _, cert := range currentChain {
-			if cert.Equal(intermediate) {
+			if cert.SubjectEqual(intermediate) {
 				continue nextIntermediate
 			}
 		}

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -671,8 +671,14 @@ func (ConstraintViolationError) Error() string {
 	return "x509: invalid signature: parent certificate cannot sign this kind of certificate"
 }
 
+// Equal returns true if the two certificates have byte-equal Raw values.
 func (c *Certificate) Equal(other *Certificate) bool {
 	return bytes.Equal(c.Raw, other.Raw)
+}
+
+// SubjectEqual returns true if the two certificates have byte-equal subjects.
+func (c *Certificate) SubjectEqual(other *Certificate) bool {
+	return bytes.Equal(c.RawSubject, other.RawSubject)
 }
 
 // Entrust have a broken root certificate (CN=Entrust.net Certification


### PR DESCRIPTION
Avoid duplicates in chains by using SubjectEquals in Verify, instead of
Equals.