### PR TITLE
Reland 1bafdfad8ce09a560d316b8b71335b5e1818f882 with fix

### DIFF
--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -686,7 +686,7 @@ func (hs *serverHandshakeState) processCertsFromClient(certificates [][]byte) (c
 			opts.Intermediates.AddCert(cert)
 		}
 
-		chains, err := certs[0].Verify(opts)
+		chains, _, _, err := certs[0].Verify(opts)
 		if err != nil {
 			c.sendAlert(alertBadCertificate)
 			return nil, errors.New("tls: failed to verify client's certificate: " + err.Error())

--- a/x509/example_test.go
+++ b/x509/example_test.go
@@ -86,7 +86,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 		Roots:   roots,
 	}
 
-	if _, err := cert.Verify(opts); err != nil {
+	if _, _, _, err := cert.Verify(opts); err != nil {
 		panic("failed to verify certificate: " + err.Error())
 	}
 }

--- a/x509/validation.go
+++ b/x509/validation.go
@@ -24,23 +24,23 @@ func (c *Certificate) ValidateWithStupidDetail(opts VerifyOptions) (chains [][]*
 		opts.CurrentTime = time.Now()
 	}
 
+	// XXX: Don't pass a KeyUsage to the Verify API
 	opts.KeyUsages = nil
+	domain := opts.DNSName
+	opts.DNSName = ""
 
 	out := new(Validation)
-	out.Domain = opts.DNSName
+	out.Domain = domain
 
-	if chains, err = c.Verify(opts); err != nil {
-		switch err := err.(type) {
-		case HostnameError:
-			out.BrowserTrusted = true
-			out.MatchesDomain = false
-		default:
-			out.BrowserTrusted = false
-			out.BrowserError = err.Error()
-		}
-	} else {
+	if chains, _, _, err = c.Verify(opts); err == nil {
 		out.BrowserTrusted = true
-		if len(opts.DNSName) > 0 {
+	}
+
+	if domain != "" {
+		if err = c.VerifyHostname(domain); err != nil {
+			out.MatchesDomain = false
+			out.BrowserError = err.Error()
+		} else {
 			out.MatchesDomain = true
 		}
 	}

--- a/x509/verify.go
+++ b/x509/verify.go
@@ -76,17 +76,19 @@ func (c *Certificate) isValid(certType CertificateType, currentChain []*Certific
 // will be of type SystemRootsError.
 //
 // WARNING: this doesn't do any revocation checking.
-func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err error) {
+func (c *Certificate) Verify(opts VerifyOptions) (current, expired, never [][]*Certificate, err error) {
 
 	// TODO: Populate with the correct OID
 	if len(c.UnhandledCriticalExtensions) > 0 {
-		return nil, UnhandledCriticalExtension{nil, ""}
+		err = UnhandledCriticalExtension{nil, ""}
+		return
 	}
 
 	if opts.Roots == nil {
 		opts.Roots = systemRootsPool()
 		if opts.Roots == nil {
-			return nil, SystemRootsError{}
+			err = SystemRootsError{}
+			return
 		}
 	}
 
@@ -114,6 +116,7 @@ func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err e
 		}
 	}
 
+	var chains [][]*Certificate
 	if hasKeyUsageAny {
 		chains = candidateChains
 	} else {
@@ -126,10 +129,11 @@ func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err e
 
 	if len(chains) == 0 {
 		err = CertificateInvalidError{c, IncompatibleUsage}
+		return
 	}
 
-	chains, expired, never := checkExpirations(chains, opts.CurrentTime)
-	if len(chains) == 0 {
+	current, expired, never = checkExpirations(chains, opts.CurrentTime)
+	if len(current) == 0 {
 		if len(expired) > 0 {
 			err = CertificateInvalidError{c, Expired}
 		} else if len(never) > 0 {

--- a/x509/verify_test.go
+++ b/x509/verify_test.go
@@ -377,7 +377,7 @@ func testVerify(t *testing.T, useSystemRoots bool) {
 			opts.Roots = nil
 		}
 
-		chains, err := leaf.Verify(opts)
+		chains, _, _, err := leaf.Verify(opts)
 
 		if test.testSystemRootsError {
 			systemRoots = oldSystemRoots


### PR DESCRIPTION
This relands the above commit, but fixes x509.ValidateWithStupidDetail
to not swap trusted/untrusted values due to a reversed error-checking if
statement.

----------

Return Current, Expired, and NeverValid chains (#20)

This updates x509.Verify() to return three different types of chains:
those that are currently valid, according to the time defined in the
VerifyOpts, chains that were valid at one time (e.g. are now expired),
and chains that were NeverValid at any time.