### PR TITLE
Set BrowserError when validation fails

### DIFF
--- a/x509/validation.go
+++ b/x509/validation.go
@@ -34,14 +34,15 @@ func (c *Certificate) ValidateWithStupidDetail(opts VerifyOptions) (chains [][]*
 	out := new(Validation)
 	out.Domain = domain
 
-	if chains, _, _, err = c.Verify(opts); err == nil {
+	if chains, _, _, err = c.Verify(opts); err != nil {
+		out.BrowserError = err.Error()
+	} else {
 		out.BrowserTrusted = true
 	}
 
 	if domain != "" {
 		if err = c.VerifyHostname(domain); err != nil {
 			out.MatchesDomain = false
-			out.BrowserError = err.Error()
 		} else {
 			out.MatchesDomain = true
 		}


### PR DESCRIPTION
We also were only setting browser error when matches_domain was checked and also false. Failing to set browser error masked the bug in ZTag