### PR TITLE
Limit max number of intermediates

### DIFF
--- a/x509/cert_pool.go
+++ b/x509/cert_pool.go
@@ -119,6 +119,20 @@ func (s *CertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
 	return
 }
 
+// Contains returns true if c is in s.
+func (s *CertPool) Contains(c *Certificate) bool {
+	candidates, ok := s.byName[string(c.RawSubject)]
+	if !ok {
+		return false
+	}
+	for _, candidateNum := range candidates {
+		if s.certs[candidateNum].Equal(c) {
+			return true
+		}
+	}
+	return false
+}
+
 // Subjects returns a list of the DER-encoded subjects of
 // all of the certificates in the pool.
 func (s *CertPool) Subjects() (res [][]byte) {
@@ -127,4 +141,11 @@ func (s *CertPool) Subjects() (res [][]byte) {
 		res[i] = c.RawSubject
 	}
 	return
+}
+
+// Certificates returns a list of parsed certificates in the pool.
+func (s *CertPool) Certificates() []*Certificate {
+	out := make([]*Certificate, 0, len(s.certs))
+	out = append(out, s.certs...)
+	return out
 }

--- a/x509/verify_test.go
+++ b/x509/verify_test.go
@@ -113,10 +113,6 @@ var verifyTests = []verifyTest{
 
 		expectedChains: [][]string{
 			{"Google", "Google Internet Authority", "GeoTrust"},
-			// TODO(agl): this is ok, but it would be nice if the
-			//            chain building didn't visit the same SPKI
-			//            twice.
-			{"Google", "Google Internet Authority", "GeoTrust", "GeoTrust"},
 		},
 		// CAPI doesn't build the chain with the duplicated GeoTrust
 		// entry so the results don't match. Thus we skip this test
@@ -144,7 +140,6 @@ var verifyTests = []verifyTest{
 		systemSkip: true,
 		expectedChains: [][]string{
 			{"dnssec-exp", "StartCom Class 1", "StartCom Certification Authority"},
-			{"dnssec-exp", "StartCom Class 1", "StartCom Certification Authority", "StartCom Certification Authority"},
 		},
 	},
 	{


### PR DESCRIPTION
This cleans up the verification function, prevents roots that are also
intermediates from appearing in a chain twice, and limits the max number
of intermediates to 10. This makes zcrypto/x509 suitable for
intermediate trawling with Censys.