### PR TITLE
Add a validation error for non-root self-signed certificates

### DIFF
--- a/x509/errors.go
+++ b/x509/errors.go
@@ -55,6 +55,10 @@ const (
 	// NeverValid results when the certificate could never have been valid due to
 	// some date-related issue, e.g. NotBefore > NotAfter.
 	NeverValid
+
+	// IsSelfSigned results when the certificate is self-signed and not a trusted
+	// root.
+	IsSelfSigned
 )
 
 // CertificateInvalidError results when an odd error occurs. Users of this

--- a/x509/verify.go
+++ b/x509/verify.go
@@ -171,6 +171,10 @@ func (c *Certificate) inChain(chain []*Certificate) bool {
 	return false
 }
 
+// buildChains returns all chains of length < maxIntermediateCount. Chains begin
+// the certificate being validated (chain[0] = c), and end at a root. It
+// enforces that all intermediates can sign certificates, and checks signatures.
+// It does not enforce expiration.
 func (c *Certificate) buildChains(cache map[int][][]*Certificate, currentChain []*Certificate, opts *VerifyOptions) (chains [][]*Certificate, err error) {
 
 	// If the certificate being validated is a root, add the chain of length one


### PR DESCRIPTION
This explicits marks root certificates as having valid chains of length
1, and marks other non-root self-signed certificates as
CertificateInvalidError with the reason IsSelfSigned. This saves us a
few crypto operations, but more importantly gives us the correct
validation result for root certificates.