### PR TITLE
Fix external ClientHello import

### DIFF
--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -84,6 +84,20 @@ func (c *ClientFingerprintConfiguration) CheckImplementedExtensions() error {
 	return nil
 }
 
+func (c *clientHelloMsg) WriteToConfig(config *Config) error {
+	config.NextProtos = c.alpnProtocols
+	config.CipherSuites = c.cipherSuites
+	config.MaxVersion = c.vers
+	config.ClientRandom = c.random
+	config.CurvePreferences = c.supportedCurves
+	config.HeartbeatEnabled = c.heartbeatEnabled
+	config.ExtendedRandom = c.extendedRandomEnabled
+	config.ForceSessionTicketExt = c.ticketSupported
+	config.ExtendedMasterSecret = c.extendedMasterSecret
+	config.SignedCertificateTimestampExt = c.sctEnabled
+	return nil
+}
+
 func (c *ClientFingerprintConfiguration) WriteToConfig(config *Config) error {
 	config.NextProtos = []string{}
 	config.CipherSuites = c.CipherSuites
@@ -285,6 +299,9 @@ func (c *Conn) clientHandshake() error {
 
 		if !hello.unmarshal(c.config.ExternalClientHello) {
 			return errors.New("could not read the ClientHello provided")
+		}
+		if err := hello.WriteToConfig(c.config); err != nil {
+			return err
 		}
 
 		// update the SNI with one name, whether or not the extension was already there


### PR DESCRIPTION
Hi,
This is a fix for https://github.com/zmap/zgrab/pull/223
The connection config needs to be updated after a raw ClientHello import, as when using a ClientHello fingerprint. Unless we do that, there is a high chance of discrepancies between the ServerHello received (based on the ClientHello we sent) and whatever zgrab is ready to negotiate (based on the config)!
The patch seems pretty straightforward but I haven't checked every field with the right test connections yet. At least I could see it worked as expected when providing cipher suites different from the defaultConfig ones. ;)