### PR TITLE
Ensure ValidateWithStupidDetail returns all errors

### DIFF
--- a/x509/validation.go
+++ b/x509/validation.go
@@ -41,10 +41,17 @@ func (c *Certificate) ValidateWithStupidDetail(opts VerifyOptions) (chains [][]*
 	}
 
 	if domain != "" {
-		if err = c.VerifyHostname(domain); err != nil {
+		nameErr := c.VerifyHostname(domain)
+		if nameErr != nil {
 			out.MatchesDomain = false
 		} else {
 			out.MatchesDomain = true
+		}
+
+		// Make sure we return an error if either chain building or hostname
+		// verification fails.
+		if err == nil && nameErr != nil {
+			err = nameErr
 		}
 	}
 	validation = out


### PR DESCRIPTION
Previously, if chain building failed but hostname verification
succeeded, ValideWithStupidDetail would incorrectly return a nil error
object, despite returning no chains and correctly populating the
Validation object.