### PR TITLE
Remove buggy subject/issuer comparison

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -751,10 +751,6 @@ func (c *Certificate) CheckSignatureFrom(parent *Certificate) (err error) {
 
 	// TODO(agl): don't ignore the path length constraint.
 
-	if parent.Subject.String() != c.Issuer.String() {
-		return errors.New("Mis-match issuer/subject")
-	}
-
 	return parent.CheckSignature(c.SignatureAlgorithm, c.RawTBSCertificate, c.Signature)
 }
 


### PR DESCRIPTION
This is one approach to resolving #63. We could switch it to `bytes.Equal(c.RawIssuer, parent.RawSubject)`, but given that not all crypto libraries do this, I suggest we start with a broad approach and then narrow it down to match specific stores. E.g. for "Firefox" or "Chrome", additionally require that issuer byte-for-byte match subject. But for Microsoft, don't require this.

Note that when building chains we do require subjects to match if there is no AKID/SKID. This "don't check if they match" commit only changes behavior for certificates that match on AKID/SKID, but don't match on Subject/Issuer.