### PR TITLE
Use byte-equality for subject and issuer

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -751,7 +751,7 @@ func (c *Certificate) CheckSignatureFrom(parent *Certificate) (err error) {
 
 	// TODO(agl): don't ignore the path length constraint.
 
-	if parent.Subject.String() != c.Issuer.String() {
+	if !bytes.Equal(parent.RawSubject, c.RawIssuer) {
 		return errors.New("Mis-match issuer/subject")
 	}
 


### PR DESCRIPTION
When chaining certificates, confirm that the parent's subject matches
the child's issuer byte-for-byte.