### PR TITLE
Clean up pkix JSON implementation and add tests

### DIFF
--- a/x509/extensions_test.go
+++ b/x509/extensions_test.go
@@ -74,7 +74,7 @@ func (s *ExtensionsSuite) TestEncodeDecodeIAN(c *C) {
 		c.Assert(jsonExtensions.IssuerAltName.IPAddresses[0].String(), Equals, ian.IPAddresses[0].String())
 
 		c.Assert(jsonExtensions.IssuerAltName.OtherNames, HasLen, len(ian.OtherNames))
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Typeid, DeepEquals, ian.OtherNames[0].Typeid)
+		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].TypeID, DeepEquals, ian.OtherNames[0].TypeID)
 		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Tag, DeepEquals, ian.OtherNames[0].Value.Tag)
 		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Class, DeepEquals, ian.OtherNames[0].Value.Class)
 		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Bytes, DeepEquals, ian.OtherNames[0].Value.Bytes)
@@ -107,7 +107,7 @@ func (s *ExtensionsSuite) TestEncodeDecodeSAN(c *C) {
 		c.Assert(jsonExtensions.SubjectAltName.IPAddresses[0].String(), Equals, san.IPAddresses[0].String())
 		// OtherNames.FullBytes is lost (should be able to reconstruct from RawValue fields)
 		c.Assert(jsonExtensions.SubjectAltName.OtherNames, HasLen, len(san.OtherNames))
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Typeid, DeepEquals, san.OtherNames[0].Typeid)
+		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].TypeID, DeepEquals, san.OtherNames[0].TypeID)
 		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Tag, DeepEquals, san.OtherNames[0].Value.Tag)
 		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Class, DeepEquals, san.OtherNames[0].Value.Class)
 		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Bytes, DeepEquals, san.OtherNames[0].Value.Bytes)

--- a/x509/pkix/json.go
+++ b/x509/pkix/json.go
@@ -167,8 +167,6 @@ func (n *Name) UnmarshalJSON(b []byte) error {
 	}
 
 	// Populate Names as []AttributeTypeAndValue
-	n.Names = appendATV(n.Names, aux.CommonName, oidCommonName)
-	n.Names = appendATV(n.Names, aux.SerialNumber, oidSerialNumber)
 	n.Names = appendATV(n.Names, aux.Country, oidCountry)
 	n.Names = appendATV(n.Names, aux.Organization, oidOrganization)
 	n.Names = appendATV(n.Names, aux.OrganizationalUnit, oidOrganizationalUnit)
@@ -177,6 +175,8 @@ func (n *Name) UnmarshalJSON(b []byte) error {
 	n.Names = appendATV(n.Names, aux.StreetAddress, oidStreetAddress)
 	n.Names = appendATV(n.Names, aux.PostalCode, oidPostalCode)
 	n.Names = appendATV(n.Names, aux.DomainComponent, oidDomainComponent)
+	n.Names = appendATV(n.Names, aux.CommonName, oidCommonName)
+	n.Names = appendATV(n.Names, aux.SerialNumber, oidSerialNumber)
 
 	// Populate specific fields as []string
 	n.Country = aux.Country

--- a/x509/pkix/json.go
+++ b/x509/pkix/json.go
@@ -7,244 +7,144 @@ package pkix
 import (
 	"encoding/asn1"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 )
 
-type jsonName struct {
-	CommonName         []string
-	SerialNumber       []string
-	Country            []string
-	Locality           []string
-	Province           []string
-	StreetAddress      []string
-	Organization       []string
-	OrganizationalUnit []string
-	PostalCode         []string
-	DomainComponent    []string //technically deprecated, but yolo
-	UnknownAttributes  []AttributeTypeAndValue
+type auxAttributeTypeAndValue struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
-func (jn *jsonName) MarshalJSON() ([]byte, error) {
-	enc := make(map[string]interface{})
-	if len(jn.CommonName) > 0 {
-		enc["common_name"] = jn.CommonName
+// MarshalJSON implements the json.Marshaler interface.
+func (a *AttributeTypeAndValue) MarshalJSON() ([]byte, error) {
+	aux := auxAttributeTypeAndValue{}
+	aux.Type = a.Type.String()
+	if s, ok := a.Value.(string); ok {
+		aux.Value = s
 	}
-	if len(jn.SerialNumber) > 0 {
-		enc["serial_number"] = jn.SerialNumber
-	}
-	if len(jn.Country) > 0 {
-		enc["country"] = jn.Country
-	}
-	if len(jn.Locality) > 0 {
-		enc["locality"] = jn.Locality
-	}
-	if len(jn.Province) > 0 {
-		enc["province"] = jn.Province
-	}
-	if len(jn.StreetAddress) > 0 {
-		enc["street_address"] = jn.StreetAddress
-	}
-	if len(jn.Organization) > 0 {
-		enc["organization"] = jn.Organization
-	}
-	if len(jn.OrganizationalUnit) > 0 {
-		enc["organizational_unit"] = jn.OrganizationalUnit
-	}
-	if len(jn.PostalCode) > 0 {
-		enc["postal_code"] = jn.PostalCode
-	}
-	if len(jn.DomainComponent) > 0 {
-		enc["domain_component"] = jn.DomainComponent
-	}
-	for _, a := range jn.UnknownAttributes {
-		enc[a.Type.String()] = a.Value
-	}
-	return json.Marshal(enc)
+	return json.Marshal(&aux)
 }
 
-func convertToStrArray(i interface{}) []string {
-
-	var strArray []string
-
-	arr, _ := i.([]interface{})
-	for _, val := range arr {
-		if str, ok := val.(string); ok {
-			strArray = append(strArray, str)
-		}
-	}
-
-	return strArray
-}
-
-func (jn *jsonName) UnmarshalJSON(b []byte) error {
-	nameMap := make(map[string]interface{})
-
-	if err := json.Unmarshal(b, &nameMap); err != nil {
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *AttributeTypeAndValue) UnmarshalJSON(b []byte) error {
+	aux := auxAttributeTypeAndValue{}
+	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
-
-	for key, val := range nameMap {
-		switch key {
-		case "common_name":
-			jn.CommonName = convertToStrArray(val)
-		case "serial_number":
-			jn.SerialNumber = convertToStrArray(val)
-		case "country":
-			jn.Country = convertToStrArray(val)
-		case "locality":
-			jn.Locality = convertToStrArray(val)
-		case "province":
-			jn.Province = convertToStrArray(val)
-		case "street_address":
-			jn.StreetAddress = convertToStrArray(val)
-		case "organization":
-			jn.Organization = convertToStrArray(val)
-		case "organizational_unit":
-			jn.OrganizationalUnit = convertToStrArray(val)
-		case "postal_code":
-			jn.PostalCode = convertToStrArray(val)
-		case "domain_component":
-			jn.DomainComponent = convertToStrArray(val)
-		default:
-			attributeType := asn1.ObjectIdentifier{}
-			valStr, okStr := val.(string)
-			if !okStr {
-				return fmt.Errorf("Expected string value for field %s, got %T", key, val)
+	a.Type = nil
+	if len(aux.Type) > 0 {
+		parts := strings.Split(aux.Type, ".")
+		for _, part := range parts {
+			i, err := strconv.Atoi(part)
+			if err != nil {
+				return err
 			}
-
-			for _, oidString := range strings.Split(valStr, ".") {
-				oidInt, err := strconv.Atoi(oidString)
-				if err != nil {
-					return err
-				}
-				attributeType = append(attributeType, oidInt)
-			}
-
-			atv := AttributeTypeAndValue{
-				Type:  attributeType,
-				Value: val,
-			}
-
-			jn.UnknownAttributes = append(jn.UnknownAttributes, atv)
+			a.Type = append(a.Type, i)
 		}
-
 	}
-
+	a.Value = aux.Value
 	return nil
 }
 
-type jsonAttributeTypeAndValue struct {
-	Type  string      `json:"type"`
-	Value interface{} `json:"value"`
+type auxOtherName struct {
+	ID    string `json:"id,omitempty"`
+	Value []byte `json:"value,omitempty"`
 }
 
-func (a *AttributeTypeAndValue) MarshalJSON() ([]byte, error) {
-	var enc jsonAttributeTypeAndValue
-	enc.Type = a.Type.String()
-	enc.Value = a.Value
-	return json.Marshal(&enc)
-}
-
-type jsonExtension struct {
-	Id       string `json:"id"`
-	Critical bool   `json:"critical"`
-	Value    []byte `json:"value"`
-}
-
-func (e *Extension) MarshalJSON() ([]byte, error) {
-	ext := jsonExtension{
-		Id:       e.Id.String(),
-		Critical: e.Critical,
-		Value:    e.Value,
-	}
-	return json.Marshal(ext)
-}
-
-type jsonOtherName struct {
-	Id    string `json:"id"`
-	Value []byte `json:"value"`
-}
-
+// MarshalJSON implements the json.Marshaler interface.
 func (o *OtherName) MarshalJSON() ([]byte, error) {
-	oName := jsonOtherName{
-		Id:    o.Typeid.String(),
+	aux := auxOtherName{
+		ID:    o.TypeID.String(),
 		Value: o.Value.Bytes,
 	}
-	return json.Marshal(oName)
+	return json.Marshal(&aux)
 }
 
-const (
-	asn1ClassUniversal       = 0
-	asn1ClassApplication     = 1
-	asn1ClassContextSpecific = 2
-	asn1ClassPrivate         = 3
-)
-
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (o *OtherName) UnmarshalJSON(b []byte) (err error) {
-	var oName jsonOtherName
-
-	if err = json.Unmarshal(b, &oName); err != nil {
+	aux := auxOtherName{}
+	if err = json.Unmarshal(b, &aux); err != nil {
 		return
 	}
 
-	arcs := strings.Split(oName.Id, ".")
-	oid := make(asn1.ObjectIdentifier, len(arcs))
-
-	for i, s := range arcs {
-		var tmp int64
-		tmp, err = strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return
-		}
-		oid[i] = int(tmp)
+	// Turn dot-notation back into an OID
+	if len(aux.ID) == 0 {
+		return errors.New("empty type ID")
 	}
-	o.Typeid = oid
+	parts := strings.Split(aux.ID, ".")
+	o.TypeID = nil
+	for _, part := range parts {
+		i, err := strconv.Atoi(part)
+		if err != nil {
+			return err
+		}
+		o.TypeID = append(o.TypeID, i)
+	}
 
+	// Build the ASN.1 value
 	o.Value = asn1.RawValue{
-		Tag: 0,
-		//TODO: change to asn1.ClassContextSpecific for next major release (i.e. 1.6)
-		Class:      asn1ClassContextSpecific,
+		Tag:        0,
+		Class:      asn1.ClassContextSpecific,
 		IsCompound: true,
-		Bytes:      oName.Value,
+		Bytes:      aux.Value,
 	}
 	o.Value.FullBytes, err = asn1.Marshal(o.Value)
 	return
 }
 
+type auxName struct {
+	CommonName         []string `json:"common_name,omitempty"`
+	SerialNumber       []string `json:"serial_number,omitempty"`
+	Country            []string `json:"country,omitempty"`
+	Locality           []string `json:"locality,omitempty"`
+	Province           []string `json:"province,omitempty"`
+	StreetAddress      []string `json:"street_address,omitempty"`
+	Organization       []string `json:"organization,omitempty"`
+	OrganizationalUnit []string `json:"organizational_unit,omitempty"`
+	PostalCode         []string `json:"postal_code,omitempty"`
+	DomainComponent    []string `json:"domain_component,omitempty"`
+
+	UnknownAttributes []AttributeTypeAndValue `json:"unknown_attributes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
 func (n *Name) MarshalJSON() ([]byte, error) {
-	var enc jsonName
+	aux := auxName{}
 	attrs := n.ToRDNSequence()
 	for _, attrSet := range attrs {
 		for _, a := range attrSet {
-			s, _ := a.Value.(string)
+			s, ok := a.Value.(string)
+			if !ok {
+				continue
+			}
 			if a.Type.Equal(oidCommonName) {
-				enc.CommonName = append(enc.CommonName, s)
+				aux.CommonName = append(aux.CommonName, s)
 			} else if a.Type.Equal(oidSerialNumber) {
-				enc.SerialNumber = append(enc.SerialNumber, s)
+				aux.SerialNumber = append(aux.SerialNumber, s)
 			} else if a.Type.Equal(oidCountry) {
-				enc.Country = append(enc.Country, s)
+				aux.Country = append(aux.Country, s)
 			} else if a.Type.Equal(oidLocality) {
-				enc.Locality = append(enc.Locality, s)
+				aux.Locality = append(aux.Locality, s)
 			} else if a.Type.Equal(oidProvince) {
-				enc.Province = append(enc.Province, s)
+				aux.Province = append(aux.Province, s)
 			} else if a.Type.Equal(oidStreetAddress) {
-				enc.StreetAddress = append(enc.StreetAddress, s)
+				aux.StreetAddress = append(aux.StreetAddress, s)
 			} else if a.Type.Equal(oidOrganization) {
-				enc.Organization = append(enc.Organization, s)
+				aux.Organization = append(aux.Organization, s)
 			} else if a.Type.Equal(oidOrganizationalUnit) {
-				enc.OrganizationalUnit = append(enc.OrganizationalUnit, s)
+				aux.OrganizationalUnit = append(aux.OrganizationalUnit, s)
 			} else if a.Type.Equal(oidPostalCode) {
-				enc.PostalCode = append(enc.PostalCode, s)
+				aux.PostalCode = append(aux.PostalCode, s)
 			} else if a.Type.Equal(oidDomainComponent) {
-				enc.DomainComponent = append(enc.DomainComponent, s)
+				aux.DomainComponent = append(aux.DomainComponent, s)
 			} else {
-				enc.UnknownAttributes = append(enc.UnknownAttributes, a)
+				aux.UnknownAttributes = append(aux.UnknownAttributes, a)
 			}
 		}
 	}
-	return json.Marshal(&enc)
+	return json.Marshal(&aux)
 }
 
 func appendATV(names []AttributeTypeAndValue, fieldVals []string, asn1Id asn1.ObjectIdentifier) []AttributeTypeAndValue {
@@ -259,54 +159,49 @@ func appendATV(names []AttributeTypeAndValue, fieldVals []string, asn1Id asn1.Ob
 	return names
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (n *Name) UnmarshalJSON(b []byte) error {
-	var jName jsonName
-
-	if err := jName.UnmarshalJSON(b); err != nil {
+	aux := auxName{}
+	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
-	// add everything to names
-	n.Names = appendATV(n.Names, jName.Country, oidCountry)
-	n.Names = appendATV(n.Names, jName.Organization, oidOrganization)
-	n.Names = appendATV(n.Names, jName.OrganizationalUnit, oidOrganizationalUnit)
-	n.Names = appendATV(n.Names, jName.Locality, oidLocality)
-	n.Names = appendATV(n.Names, jName.Province, oidProvince)
-	n.Names = appendATV(n.Names, jName.StreetAddress, oidStreetAddress)
-	n.Names = appendATV(n.Names, jName.PostalCode, oidPostalCode)
-	n.Names = appendATV(n.Names, jName.DomainComponent, oidDomainComponent)
+	// Populate Names as []AttributeTypeAndValue
+	n.Names = appendATV(n.Names, aux.CommonName, oidCommonName)
+	n.Names = appendATV(n.Names, aux.SerialNumber, oidSerialNumber)
+	n.Names = appendATV(n.Names, aux.Country, oidCountry)
+	n.Names = appendATV(n.Names, aux.Organization, oidOrganization)
+	n.Names = appendATV(n.Names, aux.OrganizationalUnit, oidOrganizationalUnit)
+	n.Names = appendATV(n.Names, aux.Locality, oidLocality)
+	n.Names = appendATV(n.Names, aux.Province, oidProvince)
+	n.Names = appendATV(n.Names, aux.StreetAddress, oidStreetAddress)
+	n.Names = appendATV(n.Names, aux.PostalCode, oidPostalCode)
+	n.Names = appendATV(n.Names, aux.DomainComponent, oidDomainComponent)
 
-	// populate specific fields
-	n.Country = jName.Country
-	n.Organization = jName.Organization
-	n.OrganizationalUnit = jName.OrganizationalUnit
-	n.Locality = jName.Locality
-	n.Province = jName.Province
-	n.StreetAddress = jName.StreetAddress
-	n.PostalCode = jName.PostalCode
-	n.DomainComponent = jName.DomainComponent
+	// Populate specific fields as []string
+	n.Country = aux.Country
+	n.Organization = aux.Organization
+	n.OrganizationalUnit = aux.OrganizationalUnit
+	n.Locality = aux.Locality
+	n.Province = aux.Province
+	n.StreetAddress = aux.StreetAddress
+	n.PostalCode = aux.PostalCode
+	n.DomainComponent = aux.DomainComponent
 
-	// add first commonNames and serialNumbers to struct and Names
-	if len(jName.CommonName) > 0 {
-		n.CommonName = jName.CommonName[0]
-		n.Names = append(n.Names, AttributeTypeAndValue{Type: oidCommonName, Value: jName.CommonName[0]})
+	// CommonName and SerialNumber are not arrays.
+	if len(aux.CommonName) > 0 {
+		n.CommonName = aux.CommonName[0]
 	}
-	if len(jName.SerialNumber) > 0 {
-		n.SerialNumber = jName.SerialNumber[0]
-		n.Names = append(n.Names, AttributeTypeAndValue{Type: oidSerialNumber, Value: jName.SerialNumber[0]})
-	}
-
-	// add extra commonNames and serialNumbers to extraNames
-	if len(jName.CommonName) > 1 {
-		for _, val := range jName.CommonName[1:] {
-			n.ExtraNames = append(n.ExtraNames, AttributeTypeAndValue{Type: oidCommonName, Value: val})
-		}
+	if len(aux.SerialNumber) > 0 {
+		n.SerialNumber = aux.SerialNumber[0]
 	}
 
-	if len(jName.SerialNumber) > 1 {
-		for _, val := range jName.SerialNumber[1:] {
-			n.ExtraNames = append(n.ExtraNames, AttributeTypeAndValue{Type: oidSerialNumber, Value: val})
-		}
+	// Add "extra" commonNames and serialNumbers to ExtraNames.
+	if len(aux.CommonName) > 1 {
+		n.ExtraNames = appendATV(n.ExtraNames, aux.CommonName[1:], oidCommonName)
+	}
+	if len(aux.SerialNumber) > 1 {
+		n.ExtraNames = appendATV(n.ExtraNames, aux.SerialNumber[1:], oidSerialNumber)
 	}
 
 	return nil

--- a/x509/pkix/json_test.go
+++ b/x509/pkix/json_test.go
@@ -7,113 +7,135 @@ package pkix
 import (
 	"encoding/asn1"
 	"encoding/json"
-	"fmt"
 	"testing"
-
-	"github.com/zmap/zgrab/ztools/zlog"
-	. "gopkg.in/check.v1"
 )
 
-func TestJSON(t *testing.T) { TestingT(t) }
-
-type JSONSuite struct {
-	name             *Name
-	ext              *Extension
-	unknownAttribute AttributeTypeAndValue
+func TestAttributeTypeValueJSON(t *testing.T) {
+	tests := []struct {
+		atv      AttributeTypeAndValue
+		expected string
+	}{
+		{
+			atv:      AttributeTypeAndValue{Type: oidCommonName, Value: "some.common.name"},
+			expected: `{"type":"2.5.4.3","value":"some.common.name"}`,
+		},
+		{
+			atv:      AttributeTypeAndValue{},
+			expected: `{}`,
+		},
+		{
+			atv:      AttributeTypeAndValue{Type: []int{}, Value: "some value"},
+			expected: `{"value":"some value"}`,
+		},
+	}
+	for i, test := range tests {
+		b, err := json.Marshal(&test.atv)
+		if len(test.expected) > 0 && err != nil {
+			t.Errorf("%d: failed marshal: %s", i, err)
+			continue
+		}
+		if s := string(b); s != test.expected {
+			t.Errorf("%d: expected %s, got %s", i, test.expected, s)
+		}
+		parsed := AttributeTypeAndValue{}
+		if err := json.Unmarshal(b, &parsed); err != nil {
+			t.Errorf("%d: could not unmarshal: %s", i, err)
+		}
+		if !test.atv.Type.Equal(parsed.Type) {
+			t.Errorf("%d: expected %v, got %v", i, test.atv.Type, parsed.Type)
+		}
+		if test.atv.Value != nil {
+			parsedValue, _ := parsed.Value.(string)
+			if test.atv.Value.(string) != parsedValue {
+				t.Errorf("%d: expected %v, got %v", i, test.atv.Value, parsed.Value)
+			}
+		}
+	}
 }
 
-var _ = Suite(&JSONSuite{})
-
-func (s *JSONSuite) SetUpTest(c *C) {
-	s.name = new(Name)
-	s.name.CommonName = "davidadrian.org"
-	s.name.SerialNumber = "12345678910"
-	s.name.Country = []string{"US"}
-	s.name.Organization = []string{"University of Michigan", "Computer Science Department"}
-	s.name.Locality = []string{"Ann Arbor"}
-	s.name.Province = []string{"MI"}
-
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidCountry, Value: s.name.Country[0]})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidOrganization, Value: s.name.Organization[0]})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidOrganization, Value: s.name.Organization[1]})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidLocality, Value: s.name.Locality[0]})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidProvince, Value: s.name.Province[0]})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidCommonName, Value: s.name.CommonName})
-	s.name.Names = append(s.name.Names, AttributeTypeAndValue{Type: oidSerialNumber, Value: s.name.SerialNumber})
-
-	s.ext = new(Extension)
-	s.ext.Id = oidCommonName
-	s.ext.Critical = true
-	s.ext.Value = []byte{1, 2, 3, 4, 5, 6, 7, 8}
-
-	s.unknownAttribute.Type = asn1.ObjectIdentifier{1, 2, 3, 4}
-	s.unknownAttribute.Value = "this is an unknown extension"
+func TestNameJSON(t *testing.T) {
+	tests := []struct {
+		name     Name
+		expected string
+	}{
+		{
+			name:     Name{},
+			expected: `{}`,
+		},
+		{
+			name: Name{
+				SerialNumber:       "12345",
+				CommonName:         "common",
+				Country:            []string{"US", "RU"},
+				Organization:       []string{"University of Michigan"},
+				OrganizationalUnit: []string{"0x21"},
+				Locality:           []string{"Ann Arbor"},
+				Province:           []string{"Michigan"},
+				StreetAddress:      []string{"2260 Hayward St"},
+				PostalCode:         []string{"48109"},
+				DomainComponent:    nil,
+				ExtraNames:         []AttributeTypeAndValue{{Type: oidCommonName, Value: "name"}, {Type: oidSerialNumber, Value: "67890"}},
+			},
+			expected: `{"common_name":["common","name"],"serial_number":["12345","67890"],"country":["US","RU"],"locality":["Ann Arbor"],"province":["Michigan"],"street_address":["2260 Hayward St"],"organization":["University of Michigan"],"organizational_unit":["0x21"],"postal_code":["48109"]}`,
+		},
+	}
+	for i, test := range tests {
+		b, err := json.Marshal(&test.name)
+		if len(test.expected) > 0 && err != nil {
+			t.Errorf("%d: failed marshal: %s", i, err)
+			continue
+		}
+		if s := string(b); s != test.expected {
+			t.Errorf("%d: expected %s, got %s", i, test.expected, s)
+		}
+		parsed := Name{}
+		if err := json.Unmarshal(b, &parsed); err != nil {
+			t.Errorf("%d: could not unmarshal: %s", i, err)
+		}
+		// TODO: Check equality of parsed and original.
+	}
 }
 
-func (s *JSONSuite) TestEncodeDecodeName(c *C) {
-	var encoded []byte
-	var err error
-	s.name.ExtraNames = append(s.name.Names, s.unknownAttribute)
-	encoded, err = json.Marshal(s.name)
-	c.Assert(err, IsNil)
-	zlog.Info(string(encoded))
-}
-
-func (s *JSONSuite) TestEncodeDecodeExtension(c *C) {
-	b, err := json.Marshal(s.ext)
-	c.Assert(err, IsNil)
-	fmt.Println(string(b))
-}
-
-func (s *JSONSuite) TestEncodeDecodeAuxOID(c *C) {
-	var oid AuxOID = []int{1, 2, 1122, 45, 8}
-	b, errEnc := json.Marshal(&oid)
-	c.Assert(errEnc, IsNil)
-	c.Assert(b, Not(IsNil))
-	c.Assert(len(b) > 0, Equals, true)
-	var dec AuxOID
-	errDec := json.Unmarshal(b, &dec)
-	c.Assert(errDec, IsNil)
-	c.Check(dec.Equal(&oid), Equals, true)
-}
-
-func (s *JSONSuite) TestNegativeOIDFailsNicely(c *C) {
-	var b = []byte("\"1.2.-88.5\"")
-	var aux AuxOID
-	errDecNeg := json.Unmarshal(b, &aux)
-	c.Assert(errDecNeg, ErrorMatches, `Invalid OID integer -\d+`)
-}
-
-func (s *JSONSuite) TestInvalidOIDFailsNicely(c *C) {
-	var b = []byte("\"1.aa4\"")
-	var aux AuxOID
-	errDecASCII := json.Unmarshal(b, &aux)
-	c.Assert(errDecASCII, ErrorMatches, `Invalid OID integer aa4`)
-	b = []byte("\"1..3\"")
-	errDecMissing := json.Unmarshal(b, &aux)
-	c.Assert(errDecMissing, ErrorMatches, `Invalid OID integer \d*`)
-}
-
-func (s *JSONSuite) TestMarshalJSON(c *C) {
-	json, err := s.name.MarshalJSON()
-	c.Assert(err, IsNil)
-	c.Assert(string(json), Equals, "{\"common_name\":[\"davidadrian.org\"],\"country\":[\"US\"],\"locality\":[\"Ann Arbor\"],\"organization\":[\"University of Michigan\",\"Computer Science Department\"],\"province\":[\"MI\"],\"serial_number\":[\"12345678910\"]}")
-}
-
-func (s *JSONSuite) TestUnmarshalJSON(c *C) {
-	var newName Name
-	jsonStr := "{\"common_name\":[\"davidadrian.org\"],\"country\":[\"US\"],\"locality\":[\"Ann Arbor\"],\"organization\":[\"University of Michigan\",\"Computer Science Department\"],\"province\":[\"MI\"],\"serial_number\":[\"12345678910\"]}"
-	err := newName.UnmarshalJSON([]byte(jsonStr))
-	c.Assert(err, IsNil)
-	c.Assert(newName, DeepEquals, *s.name)
-}
-
-func (s *JSONSuite) TestMarshalUnmarshalJSON(c *C) {
-	json, err := s.name.MarshalJSON()
-	c.Assert(err, IsNil)
-	jsonStr := string(json)
-	var newName Name
-	err = newName.UnmarshalJSON([]byte(jsonStr))
-	c.Assert(err, IsNil)
-	c.Assert(newName, DeepEquals, *s.name)
+func TestOtherNameJSON(t *testing.T) {
+	tests := []struct {
+		otherName OtherName
+		expected  string
+		unmarshal bool
+	}{
+		{
+			otherName: OtherName{},
+			expected:  `{}`,
+			unmarshal: false,
+		},
+		{
+			otherName: OtherName{
+				TypeID: asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 2, 2}, // image/JPEG 2.16.840.1.113730.2.2
+				Value: asn1.RawValue{
+					Tag:        0,
+					Class:      asn1.ClassContextSpecific,
+					IsCompound: true,
+					Bytes:      []byte{0, 1, 2, 3, 4, 5},
+				},
+			},
+			expected:  `{"id":"2.16.840.1.113730.2.2","value":"AAECAwQF"}`,
+			unmarshal: true,
+		},
+	}
+	for i, test := range tests {
+		b, err := json.Marshal(&test.otherName)
+		if len(test.expected) > 0 && err != nil {
+			t.Errorf("%d: unabled to marshal: %s", i, err)
+			continue
+		}
+		if s := string(b); s != test.expected {
+			t.Errorf("%d: expected %s, got %s", i, test.expected, s)
+		}
+		parsed := OtherName{}
+		if test.unmarshal {
+			if err := json.Unmarshal(b, &parsed); err != nil {
+				t.Errorf("%d: could not unmarshal: %s", i, err)
+			}
+			// TODO: Check equality of parsed and original
+		}
+	}
 }

--- a/x509/pkix/pkix.go
+++ b/x509/pkix/pkix.go
@@ -49,13 +49,13 @@ type Extension struct {
 // Name represents an X.509 distinguished name. This only includes the common
 // elements of a DN.  Additional elements in the name are ignored.
 type Name struct {
-	Country, Organization, OrganizationalUnit  []string `json:"omitempty"`
-	Locality, Province                         []string `json:"omitempty"`
-	StreetAddress, PostalCode, DomainComponent []string `json:"omitempty"`
-	SerialNumber, CommonName                   string   `json:"omitempty"`
+	Country, Organization, OrganizationalUnit  []string
+	Locality, Province                         []string
+	StreetAddress, PostalCode, DomainComponent []string
+	SerialNumber, CommonName                   string
 
-	Names      []AttributeTypeAndValue `json:"omitempty"`
-	ExtraNames []AttributeTypeAndValue `json:"omitempty"`
+	Names      []AttributeTypeAndValue
+	ExtraNames []AttributeTypeAndValue
 }
 
 func (n *Name) FillFromRDNSequence(rdns *RDNSequence) {
@@ -223,7 +223,7 @@ type RevokedCertificate struct {
 // OtherName represents the ASN.1 structure of the same name. See RFC
 // 5280, section 4.2.1.6.
 type OtherName struct {
-	Typeid asn1.ObjectIdentifier
+	TypeID asn1.ObjectIdentifier
 	Value  asn1.RawValue `asn1:"explicit"`
 }
 


### PR DESCRIPTION
Previously, the JSON implementation for pkix objects was implemented
without knowledge of `omitempty`. This makes the implementation more
modern and in-line with how we serialize to JSON in Golang. This will
also make it easier to output emailAddresses parsed in DN's (#62).

Fixes #66 