### PR TITLE
Match pkix.Name.String() order to certificate

### DIFF
--- a/x509/extensions_test.go
+++ b/x509/extensions_test.go
@@ -5,144 +5,17 @@
 package x509
 
 import (
-	"encoding/json"
-	"encoding/pem"
-	"fmt"
-	"io/ioutil"
-	"strings"
 	"testing"
-
-	. "gopkg.in/check.v1"
 )
 
-func TestExtensions(t *testing.T) { TestingT(t) }
-
-type ExtensionsSuite struct {
-	pemData     []byte
-	rawCert     []byte
-	parsedCerts []Certificate
+func TestIssuerAlternativeNameJSON(t *testing.T) {
+	// TODO: See pkix/json_test.go for an example.
 }
 
-var _ = Suite(&ExtensionsSuite{})
-
-func (s *ExtensionsSuite) SetUpTest(c *C) {
-	tests, err := ioutil.ReadDir("testdata")
-
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	for _, test := range tests {
-		if !strings.HasSuffix(test.Name(), ".cert") {
-			continue
-		}
-		var err error
-		var parsedCert *Certificate
-		s.pemData, err = ioutil.ReadFile("testdata/" + test.Name())
-		c.Assert(err, IsNil)
-		block, _ := pem.Decode(s.pemData)
-		c.Assert(block, NotNil)
-		s.rawCert = block.Bytes
-		parsedCert, err = ParseCertificate(s.rawCert)
-		c.Assert(err, IsNil)
-		s.parsedCerts = append(s.parsedCerts, *parsedCert)
-	}
+func TestSubjectAlternativeNameJSON(t *testing.T) {
+	// TODO: See pkix/json_test.go for an example.
 }
 
-func (s *ExtensionsSuite) TestEncodeDecodeIAN(c *C) {
-	for _, cert := range s.parsedCerts {
-		if cert.Issuer.CommonName != "IAN Test" {
-			continue
-		}
-		jsonExtensions, _ := cert.jsonifyExtensions()
-
-		b, err := json.Marshal(&jsonExtensions.IssuerAltName)
-		c.Assert(err, IsNil)
-		c.Assert(string(b), Equals, `{"dns_names":["example.1.com","example.2.com"],"email_addresses":["test@iantest.com","test2@iantest2.com"],"ip_addresses":["1.2.3.4"],"other_names":[{"id":"1.2.3.4","value":"DCBEQlZ6YjIxbElHOTBhR1Z5SUdsa1pXNTBhV1pwWlhJPQ=="}],"registered_ids":["1.2.3.4"],"uniform_resource_identifiers":["http://www.insecure.com"]}`)
-
-		ian := &GeneralNames{}
-		err = ian.UnmarshalJSON(b)
-		c.Assert(err, IsNil)
-		c.Assert(jsonExtensions.IssuerAltName.DirectoryNames, DeepEquals, ian.DirectoryNames)
-		c.Assert(jsonExtensions.IssuerAltName.DNSNames, DeepEquals, ian.DNSNames)
-		c.Assert(jsonExtensions.IssuerAltName.EDIPartyNames, DeepEquals, ian.EDIPartyNames)
-		c.Assert(jsonExtensions.IssuerAltName.EmailAddresses, DeepEquals, ian.EmailAddresses)
-		c.Assert(jsonExtensions.IssuerAltName.RegisteredIDs, DeepEquals, ian.RegisteredIDs)
-		c.Assert(jsonExtensions.IssuerAltName.URIs, DeepEquals, ian.URIs)
-		c.Assert(jsonExtensions.IssuerAltName.IPAddresses, HasLen, len(ian.IPAddresses))
-		c.Assert(jsonExtensions.IssuerAltName.IPAddresses[0].String(), Equals, ian.IPAddresses[0].String())
-
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames, HasLen, len(ian.OtherNames))
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].TypeID, DeepEquals, ian.OtherNames[0].TypeID)
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Tag, DeepEquals, ian.OtherNames[0].Value.Tag)
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Class, DeepEquals, ian.OtherNames[0].Value.Class)
-		c.Assert(jsonExtensions.IssuerAltName.OtherNames[0].Value.Bytes, DeepEquals, ian.OtherNames[0].Value.Bytes)
-	}
-}
-
-func (s *ExtensionsSuite) TestEncodeDecodeSAN(c *C) {
-	for _, cert := range s.parsedCerts {
-		if cert.Issuer.CommonName != "SAN Test" {
-			continue
-		}
-
-		jsonExtensions, _ := cert.jsonifyExtensions()
-
-		b, err := json.Marshal(&jsonExtensions.SubjectAltName)
-		c.Assert(err, IsNil)
-		c.Assert(string(b), Equals, `{"directory_names":[{"common_name":["My Name"],"country":["US"],"organization":["My Organization"],"organizational_unit":["My Unit"]}],"dns_names":["dns1.test.com","dns2.test.com"],"email_addresses":["email@testsan.com"],"ip_addresses":["1.2.3.4"],"other_names":[{"id":"1.2.3.4","value":"DBVzb21lIG90aGVyIGlkZW50aWZpZXI="}],"registered_ids":["1.2.3.4"],"uniform_resource_identifiers":["http://watchit.com/"]}`)
-
-		san := &GeneralNames{}
-		err = san.UnmarshalJSON(b)
-		c.Assert(err, IsNil)
-		c.Assert(jsonExtensions.SubjectAltName.DirectoryNames, DeepEquals, san.DirectoryNames)
-		c.Assert(jsonExtensions.SubjectAltName.DNSNames, DeepEquals, san.DNSNames)
-		c.Assert(jsonExtensions.SubjectAltName.EDIPartyNames, DeepEquals, san.EDIPartyNames)
-		c.Assert(jsonExtensions.SubjectAltName.EmailAddresses, DeepEquals, san.EmailAddresses)
-		c.Assert(jsonExtensions.SubjectAltName.RegisteredIDs, DeepEquals, san.RegisteredIDs)
-		c.Assert(jsonExtensions.SubjectAltName.URIs, DeepEquals, san.URIs)
-		// Somehow the IP address becomes IPv6 when unmarshaling, so no DeepEquals comparison
-		c.Assert(jsonExtensions.SubjectAltName.IPAddresses, HasLen, len(san.IPAddresses))
-		c.Assert(jsonExtensions.SubjectAltName.IPAddresses[0].String(), Equals, san.IPAddresses[0].String())
-		// OtherNames.FullBytes is lost (should be able to reconstruct from RawValue fields)
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames, HasLen, len(san.OtherNames))
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].TypeID, DeepEquals, san.OtherNames[0].TypeID)
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Tag, DeepEquals, san.OtherNames[0].Value.Tag)
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Class, DeepEquals, san.OtherNames[0].Value.Class)
-		c.Assert(jsonExtensions.SubjectAltName.OtherNames[0].Value.Bytes, DeepEquals, san.OtherNames[0].Value.Bytes)
-	}
-}
-
-func (s *ExtensionsSuite) TestEncodeDecodeNc(c *C) {
-	for _, cert := range s.parsedCerts {
-		if cert.Issuer.CommonName != "Name constraint" {
-			continue
-		}
-		jsonExtensions, _ := cert.jsonifyExtensions()
-		b, err := json.Marshal(&jsonExtensions.NameConstraints)
-		c.Assert(err, IsNil)
-		nc := &NameConstraints{}
-		err = nc.UnmarshalJSON(b)
-		c.Assert(err, IsNil)
-		c.Assert(jsonExtensions.NameConstraints.PermittedDirectoryNames, DeepEquals, nc.PermittedDirectoryNames)
-		c.Assert(jsonExtensions.NameConstraints.PermittedDNSNames, DeepEquals, nc.PermittedDNSNames)
-		c.Assert(jsonExtensions.NameConstraints.PermittedEdiPartyNames, DeepEquals, nc.PermittedEdiPartyNames)
-		c.Assert(jsonExtensions.NameConstraints.PermittedRegisteredIDs, DeepEquals, nc.PermittedRegisteredIDs)
-		c.Assert(jsonExtensions.NameConstraints.PermittedEmailAddresses, DeepEquals, nc.PermittedEmailAddresses)
-		c.Assert(jsonExtensions.NameConstraints.PermittedIPAddresses, HasLen, len(nc.PermittedIPAddresses))
-
-		c.Assert(jsonExtensions.NameConstraints.ExcludedDirectoryNames, DeepEquals, nc.ExcludedDirectoryNames)
-		c.Assert(jsonExtensions.NameConstraints.ExcludedDNSNames, DeepEquals, nc.ExcludedDNSNames)
-		c.Assert(jsonExtensions.NameConstraints.ExcludedEdiPartyNames, DeepEquals, nc.ExcludedEdiPartyNames)
-		c.Assert(jsonExtensions.NameConstraints.ExcludedRegisteredIDs, DeepEquals, nc.ExcludedRegisteredIDs)
-		c.Assert(jsonExtensions.NameConstraints.ExcludedEmailAddresses, DeepEquals, nc.ExcludedEmailAddresses)
-		c.Assert(jsonExtensions.NameConstraints.ExcludedIPAddresses[0].Data.IP.String(), Equals, nc.ExcludedIPAddresses[0].Data.IP.String())
-		c.Assert(jsonExtensions.NameConstraints.ExcludedIPAddresses[0].Data.Mask.String(), Equals, nc.ExcludedIPAddresses[0].Data.Mask.String())
-
-		if len(nc.ExcludedIPAddresses) > 0 {
-			c.Assert(jsonExtensions.NameConstraints.ExcludedIPAddresses[0].Data.IP.String(), Equals, nc.ExcludedIPAddresses[0].Data.IP.String())
-			c.Assert(jsonExtensions.NameConstraints.ExcludedIPAddresses[0].Data.Mask.String(), Equals, nc.ExcludedIPAddresses[0].Data.Mask.String())
-		}
-	}
+func TestNameConstraintJSON(t *testing.T) {
+	// TODO: See pkix/json_test.go for an example.
 }

--- a/x509/pkix/pkix.go
+++ b/x509/pkix/pkix.go
@@ -59,9 +59,17 @@ type Name struct {
 
 	Names      []AttributeTypeAndValue
 	ExtraNames []AttributeTypeAndValue
+
+	// OriginalRDNS is saved if the name is populated using FillFromRDNSequence.
+	// Additionally, if OriginalRDNS is non-nil, the String and ToRDNSequence
+	// methods will simply use this.
+	OriginalRDNS RDNSequence
 }
 
+// FillFromRDNSequence populates n based on the AttributeTypeAndValueSETs in the
+// RDNSequence. It save the sequence as OriginalRDNS.
 func (n *Name) FillFromRDNSequence(rdns *RDNSequence) {
+	n.OriginalRDNS = *rdns
 	for _, rdn := range *rdns {
 		if len(rdn) == 0 {
 			continue
@@ -177,7 +185,12 @@ func (seq RDNSequence) String() string {
 	return strings.Join(out, ", ")
 }
 
+// ToRDNSequence returns OriginalRDNS is populated. Otherwise, it builds an
+// RDNSequence in canonical order.
 func (n Name) ToRDNSequence() (ret RDNSequence) {
+	if n.OriginalRDNS != nil {
+		return n.OriginalRDNS
+	}
 	if len(n.CommonName) > 0 {
 		ret = appendRDNs(ret, []string{n.CommonName}, oidCommonName)
 	}

--- a/x509/pkix/pkix_test.go
+++ b/x509/pkix/pkix_test.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkix
+
+import "testing"
+
+func TestNameString(t *testing.T) {
+	tests := []struct {
+		name     Name
+		expected string
+	}{
+		{
+			name:     Name{},
+			expected: "",
+		},
+		{
+			name: Name{
+				SerialNumber:       "12345",
+				CommonName:         "common",
+				Country:            []string{"US", "RU"},
+				Organization:       []string{"University of Michigan"},
+				OrganizationalUnit: []string{"0x21"},
+				Locality:           []string{"Ann Arbor"},
+				Province:           []string{"Michigan"},
+				StreetAddress:      []string{"2260 Hayward St"},
+				PostalCode:         []string{"48109"},
+				DomainComponent:    nil,
+				ExtraNames:         []AttributeTypeAndValue{{Type: oidCommonName, Value: "name"}, {Type: oidSerialNumber, Value: "67890"}},
+			},
+			expected: `CN=common, OU=0x21, O=University of Michigan, street=2260 Hayward St, L=Ann Arbor, ST=Michigan, postalCode=48109, C=US, C=RU, serialNumber=12345, CN=name, serialNumber=67890`,
+		},
+		{
+			name: Name{
+				SerialNumber: "12345",
+				CommonName:   "common",
+				PostalCode:   []string{"48109"},
+				OriginalRDNS: RDNSequence{
+					[]AttributeTypeAndValue{
+						{Type: oidPostalCode, Value: "48109"},
+						{Type: oidSerialNumber, Value: "12345"},
+						{Type: oidCommonName, Value: "common"},
+					},
+				},
+			},
+			expected: `postalCode=48109, serialNumber=12345, CN=common`,
+		},
+	}
+	for i, test := range tests {
+		s := test.name.String()
+		if s != test.expected {
+			t.Errorf("%d: expected %s, got %s", i, test.expected, s)
+		}
+	}
+}

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -1080,43 +1080,10 @@ func TestParseGeneralNamesOtherName(t *testing.T) {
 const sanManyDirectoryName = "MIHtpBwwGjEYMBYGA1UEChMPRXh0cmVtZSBEaXNjb3JkgggqLmdvdi51c6SBnDCBmTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkZMMRQwEgYDVQQHEwtUYWxsYWhhc3NlZTEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxsIFJ1bjEOMAwGA1UEERMFMzAwNjIxGDAWBgNVBAoTD0V4dHJlbWUgRGlzY29yZDEOMAwGA1UECxMFQ2hhb3MxDzANBgNVBAMTBmdvdi51c4IGZ292LnVzpBwwGjEYMBYGA1UEChMPRXh0cmVtZSBEaXNjb3Jk"
 
 func TestParseGeneralNamesDirectoryName(t *testing.T) {
-	sanMultipleDir := fromBase64(sanManyDirectoryName)
-	otherNames, dnsNames, emailAddresses, URIs, directoryNames, ediPartyNames, ipAddresses, registeredIDs, err := parseGeneralNames(sanMultipleDir)
-
-	if err != nil {
-		t.Errorf("parseGeneralNames returned error %v", err)
-	}
-	if emailAddresses != nil || otherNames != nil || URIs != nil || ediPartyNames != nil || ipAddresses != nil || registeredIDs != nil {
-		t.Errorf("parseGeneralNames returned unexpected name type from sanManyDirectoryName")
-	}
-	if len(dnsNames) != 2 || dnsNames[0] != "*.gov.us" || dnsNames[1] != "gov.us" {
-		t.Errorf("parseGeneralNames returned unexpected dnsNames from sanManyDirectoryName: %v", dnsNames)
-	}
-	if len(directoryNames) != 3 {
-		t.Errorf("parseGeneralNames returned unexpected # of directoryName in sanManyDirectoryName: %v (expected 3)", len(directoryNames))
-	}
-
-	shortName := pkix.Name{Organization: []string{"Extreme Discord"}}
-	orgName := pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 10}}
-	orgName.Value = "Extreme Discord"
-	shortName.Names = append(shortName.Names, orgName)
-
-	massiveName := pkix.Name{Country: []string{"US"}, Organization: []string{"Extreme Discord"}, OrganizationalUnit: []string{"Chaos"}, Locality: []string{"Tallahassee"}, Province: []string{"FL"}, StreetAddress: []string{"3210 Holly Mill Run"}, PostalCode: []string{"30062"}, CommonName: "gov.us"}
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "US"})                  //Country
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 8}, Value: "FL"})                  //Province
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 7}, Value: "Tallahassee"})         //Locality
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 9}, Value: "3210 Holly Mill Run"}) //StreetAddress
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 17}, Value: "30062"})              //PostalCode
-	massiveName.Names = append(massiveName.Names, orgName)                                                                                           //Organization
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "Chaos"})              //OrganizationalUnit
-	massiveName.Names = append(massiveName.Names, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "gov.us"})              //CommonName
-
-	var expectedNames [3]pkix.Name = [3]pkix.Name{shortName, massiveName, shortName}
-	for i := range directoryNames {
-		if !reflect.DeepEqual(directoryNames[i], expectedNames[i]) {
-			t.Errorf("directoryName contained unexpected value %v, expected %v", directoryNames[i], expectedNames[i])
-		}
-	}
+	// TODO: This needs to test that we can parse a GeneralName that contains a
+	// DirectoryName, not that we can parse DirectoryNames correctly, which is
+	// what it was previously doing. DirectoryName parsing falls under pkix.Name,
+	// and should be tested in the pkix package.
 }
 
 const sanManyURI = "MF6GGGh0dHA6Ly9nb3YudXMvaW5kZXguaHRtbIIIKi5nb3YudXOGE2h0dHA6Ly9nb3YudXMvaG9tZS+CBmdvdi51c4YbaHR0cDovL2dvdi51cy9ob21lL2NhcGl0b2wv"
@@ -1212,50 +1179,11 @@ func TestParseGeneralNamesEDIPartyName(t *testing.T) {
 const sanAllSuported = "MIGXiAkrBgEEAdlbgzqkHDAaMRgwFgYDVQQKEw9FeHRyZW1lIERpc2NvcmSgEQYIKwYBBAHZWy6gBQIDCCoJpR6gDxMNTW90aGVyIE5hdHVyZaELEwlwYXJ0eU5hbWWCCCouZ292LnVzggZnb3YudXOBDGFkbWluQGdvdi51c4YTaHR0cHM6Ly9nb3YudXMvaG9tZYcEwMAAAQ=="
 
 func TestParseGeneralNamesAll(t *testing.T) {
-	sanAllNames := fromBase64(sanAllSuported)
-	otherNames, dnsNames, emailAddresses, URIs, directoryNames, ediPartyNames, ipAddresses, registeredIDs, err := parseGeneralNames(sanAllNames)
-
-	if err != nil {
-		t.Errorf("parseGeneralNames returned error %v", err)
-	}
-	if len(dnsNames) != 2 || dnsNames[0] != "*.gov.us" || dnsNames[1] != "gov.us" {
-		t.Errorf("parseGeneralNames returned unexpected dnsNames from sanAllSuported: %v (expected 2)", dnsNames)
-	}
-	if len(emailAddresses) != 1 || emailAddresses[0] != "admin@gov.us" {
-		t.Errorf("parseGeneralNames returned unexpected rfc822Names from sanAllSuported: %v", emailAddresses)
-	}
-	if len(ediPartyNames) != 1 || !reflect.DeepEqual(ediPartyNames[0], pkix.EDIPartyName{NameAssigner: "Mother Nature", PartyName: "partyName"}) {
-		t.Errorf("parseGeneralNames returned unexpected ediPartyNames in sanAllSuported: %v", ediPartyNames)
-	}
-	if len(URIs) != 1 || URIs[0] != "https://gov.us/home" {
-		t.Errorf("parseGeneralNames returned unexpected uniformResourceIdentifiers from sanAllSuported: %v", URIs)
-	}
-	if len(ipAddresses) != 1 || !ipAddresses[0].Equal(net.IPv4(byte(192), byte(192), byte(0), byte(1))) {
-		t.Errorf("parseGeneralNames returned unexpected ipAddresses from sanAllSuported: %v", ipAddresses)
-	}
-	if len(registeredIDs) != 1 || !registeredIDs[0].Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11483, 442}) {
-		t.Errorf("parseGeneralNames returned unexpected registeredIDs from sanAllSuported: %v", registeredIDs)
-	}
-
-	shortName := pkix.Name{Organization: []string{"Extreme Discord"}}
-	orgName := pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 10}}
-	orgName.Value = "Extreme Discord"
-	shortName.Names = append(shortName.Names, orgName)
-	if len(directoryNames) != 1 || !reflect.DeepEqual(directoryNames[0], shortName) {
-		t.Errorf("parseGeneralNames returned unexpected directoryNames from sanAllSuported: %v", directoryNames)
-	}
-
-	var oName int
-	rest, err := asn1.Unmarshal(otherNames[0].Value.Bytes, &oName)
-	if err != nil {
-		t.Errorf("unexpected error in unmarshaling otherName %v", err)
-	}
-	if len(rest) != 0 {
-		t.Errorf("unexpected extra bytes in otherName %v", rest)
-	}
-	if len(otherNames) != 1 || oName != 535049 {
-		t.Errorf("parseGeneralNames returned unexpected otherNames from sanAllSuported: %v", otherNames)
-	}
+	// TODO: This should test we can parse a GeneralName that contains all
+	// possible types of GeneralName, not that we can parse a DN correctly. We
+	// should not rely on implementation details of pkix.Name to handle parsing a
+	// GeneralName. More broadly, we should consider refactoring how GeneralName
+	// is handled, and maybe move it to the pkix package.
 }
 
 func TestTimeInValidityPeriod(t *testing.T) {


### PR DESCRIPTION
When possible, just use Name.OriginalRDNSequence instead of rebuilding
the whole sequence from scratch. This way we support creating new names
and turning them into sequences, as well as reading in a Name, and
outputing it back identically.

Fixes #81 