### PR TITLE
Add ParsedDomainName map to the Certificat struct to allow speeding up zlint

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -42,6 +42,7 @@ type pkixPublicKey struct {
 	BitString asn1.BitString
 }
 
+// ParsedDomainName is a structure holding a parsed domain name (CommonName or DNS SAN) and a parsing error.
 type ParsedDomainName struct {
 	Domain     *publicsuffix.DomainName
 	ParseError error

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/zmap/zcrypto/ct"
 	"github.com/zmap/zcrypto/x509/pkix"
+
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
 
 // pkixPublicKey reflects a PKIX public key structure. See SubjectPublicKeyInfo
@@ -38,6 +40,11 @@ import (
 type pkixPublicKey struct {
 	Algo      pkix.AlgorithmIdentifier
 	BitString asn1.BitString
+}
+
+type ParsedDomainName struct {
+	Domain     *publicsuffix.DomainName
+	ParseError error
 }
 
 // ParsePKIXPublicKey parses a DER encoded public key. These values are
@@ -628,6 +635,11 @@ type Certificate struct {
 
 	// CT
 	SignedCertificateTimestampList []*ct.SignedCertificateTimestamp
+
+	// Used to speed up the zlint checks. Populated by zlint.
+	// Each map key is a potential domain name ( CommonName or DNS SAN)
+	// Each corresponding key is a structure holding a parsed domain name and a parsing error
+	ParsedDomainsMap map[string]ParsedDomainName
 }
 
 // SubjectAndKey represents a (subjecty, subject public key info) tuple.
@@ -1551,6 +1563,7 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 		//	return out, UnhandledCriticalExtension{e.Id}
 		//}
 	}
+
 	return out, nil
 }
 

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2147,33 +2147,28 @@ func (c *Certificate) CreateCRL(rand io.Reader, priv interface{}, revokedCerts [
 // domain name components from it. Parsed domain info and parsing error are subsequently stored in the ParsedDomainsMap.
 // The ParsedDomainsMap is used as a cache by zlint to speed up the slowest lints.
 func (c *Certificate) PopulateDomainsMap() {
-	var parseError error
-	var parsedDomain *publicsuffix.DomainName
 	c.ParsedDomainsMap = make(map[string]ParsedDomainName)
 
 	if c.Subject.CommonName != "" {
-		parsedDomain, parseError = publicsuffix.ParseFromListWithOptions(publicsuffix.DefaultList,
-			c.Subject.CommonName,
-			&publicsuffix.FindOptions{IgnorePrivate: true, DefaultRule: publicsuffix.DefaultRule})
-
-		c.ParsedDomainsMap[c.Subject.CommonName] = ParsedDomainName{
-			Domain:     parsedDomain,
-			ParseError: parseError,
-		}
+		c.parseDomainAndAddToMap(c.Subject.CommonName)
 	}
 
 	for _, DNSName := range c.DNSNames {
 		if DNSName == "" {
 			continue
 		}
-		parsedDomain, parseError = publicsuffix.ParseFromListWithOptions(publicsuffix.DefaultList,
-			DNSName,
-			&publicsuffix.FindOptions{IgnorePrivate: true, DefaultRule: publicsuffix.DefaultRule})
+		c.parseDomainAndAddToMap(DNSName)
+	}
+}
 
-		c.ParsedDomainsMap[DNSName] = ParsedDomainName{
-			Domain:     parsedDomain,
-			ParseError: parseError,
-		}
+func (c *Certificate) parseDomainAndAddToMap(domain string) {
+	var parsedDomain, parseError = publicsuffix.ParseFromListWithOptions(publicsuffix.DefaultList,
+		domain,
+		&publicsuffix.FindOptions{IgnorePrivate: true, DefaultRule: publicsuffix.DefaultRule})
+
+	c.ParsedDomainsMap[domain] = ParsedDomainName{
+		Domain:     parsedDomain,
+		ParseError: parseError,
 	}
 }
 


### PR DESCRIPTION
I have added a `ParsedDomainsMap map[string]ParsedDomainName` to the certificate struct. 
It will hold parsed DNS names (either CommonName or SAN DNS), and a parsing error, where the key is the domain name string. 
By parsing the domain names once and reusing in in multiple zlint linters the slowes linters could be sped up tremendously.
