### PR TITLE
TLSCertsOnly Option

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -496,6 +496,10 @@ type Config struct {
 	// material from the returned config will be used for session tickets.
 	GetConfigForClient func(*ClientHelloInfo) (*Config, error)
 
+	// TLSCertsOnly is used to cause a client to close the TLS connection
+	// as soon as the server's certificates have been received
+	TLSCertsOnly bool
+
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex
 	// sessionTicketKeys contains zero or more ticket keys. If the length

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,9 +515,10 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
-
-		return nil
-
+        if c.config.TLSCertsOnly {
+            // All done
+		    return nil
+        }
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -612,7 +613,6 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
 			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
 
-
 			// If actually verifying and invalid, reject
 			if !c.config.InsecureSkipVerify {
 				if err != nil {
@@ -670,7 +670,6 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	// If we don't support the cipher, quit before we need to read the hs.suite

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,6 +515,9 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
+
+		return nil
+
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -583,6 +586,11 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 
 		c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 
+		if c.config.TLSCertsOnly {
+		  // short circuit!
+  		  return nil
+		}
+
 		if !invalidCert {
 			opts := x509.VerifyOptions{
 				Roots:         c.config.RootCAs,
@@ -603,6 +611,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			var validation *x509.Validation
 			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
 			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
+
 
 			// If actually verifying and invalid, reject
 			if !c.config.InsecureSkipVerify {
@@ -661,6 +670,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		if err != nil {
 			return err
 		}
+
 	}
 
 	// If we don't support the cipher, quit before we need to read the hs.suite


### PR DESCRIPTION
This PR is concomitant with my PR to zgrab (which implements the option).

This option allows clients to abort the connection after receiving the server_certificates message.  This allows offline certificate parsing and validation (which is expensive), freeing up resources and allowing the scanning host to move faster.