### PR TITLE
Finish handshake skip validation

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -496,6 +496,10 @@ type Config struct {
 	// material from the returned config will be used for session tickets.
 	GetConfigForClient func(*ClientHelloInfo) (*Config, error)
 
+	// TLSCertsOnly is used to cause a client to close the TLS connection
+	// as soon as the server's certificates have been received
+	TLSCertsOnly bool
+
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex
 	// sessionTicketKeys contains zero or more ticket keys. If the length

--- a/tls/common.go
+++ b/tls/common.go
@@ -1272,4 +1272,4 @@ func (config *Config) UnmarshalJSON(b []byte) error {
 
 // Error type raised by doFullHandshake() when the CertsOnly option is
 // in use
-var ErrCertsOnly = errors.New("handshake abandoned per TLSCertsOnly option")
+var ErrCertsOnly = errors.New("handshake abandoned per CertsOnly option")

--- a/tls/common.go
+++ b/tls/common.go
@@ -389,6 +389,10 @@ type Config struct {
 	// This should be used only for testing.
 	InsecureSkipVerify bool
 
+	// Like InsecureSkipVerify but skips used to skip certificate parsing
+	// altogether.  Useful for offline processing of scanning results.
+	InsecureSkipValidation bool
+
 	// CipherSuites is a list of supported cipher suites. If CipherSuites
 	// is nil, TLS uses a list of suites supported by the implementation.
 	CipherSuites []uint16
@@ -499,9 +503,6 @@ type Config struct {
 	// CertsOnly is used to cause a client to close the TLS connection
 	// as soon as the server's certificates have been received
 	CertsOnly bool
-
-	// SkipValidation is used to skip certificate parsing and validation
-	SkipValidation bool
 
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex
@@ -1207,6 +1208,7 @@ type ConfigJSON struct {
 	ClientAuth                     ClientAuthType                  `json:"client_auth_type"`
 	ClientCAs                      *x509.CertPool                  `json:"client_cas,omitempty"`
 	InsecureSkipVerify             bool                            `json:"skip_verify"`
+	InsecureSkipValidation         bool                            `json:"skip_validation"`
 	CipherSuites                   []CipherSuite                   `json:"cipher_suites,omitempty"`
 	PreferServerCipherSuites       bool                            `json:"prefer_server_cipher_suites"`
 	SessionTicketsDisabled         bool                            `json:"session_tickets_disabled"`
@@ -1239,6 +1241,7 @@ func (config *Config) MarshalJSON() ([]byte, error) {
 	aux.ClientAuth = config.ClientAuth
 	aux.ClientCAs = config.ClientCAs
 	aux.InsecureSkipVerify = config.InsecureSkipVerify
+	aux.InsecureSkipValidation = config.InsecureSkipValidation
 
 	ciphers := config.cipherSuites()
 	aux.CipherSuites = make([]CipherSuite, len(ciphers))

--- a/tls/common.go
+++ b/tls/common.go
@@ -496,9 +496,9 @@ type Config struct {
 	// material from the returned config will be used for session tickets.
 	GetConfigForClient func(*ClientHelloInfo) (*Config, error)
 
-	// TLSCertsOnly is used to cause a client to close the TLS connection
+	// CertsOnly is used to cause a client to close the TLS connection
 	// as soon as the server's certificates have been received
-	TLSCertsOnly bool
+	CertsOnly bool
 
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex

--- a/tls/common.go
+++ b/tls/common.go
@@ -500,6 +500,9 @@ type Config struct {
 	// as soon as the server's certificates have been received
 	CertsOnly bool
 
+	// SkipValidation is used to skip certificate parsing and validation
+	SkipValidation bool
+
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex
 	// sessionTicketKeys contains zero or more ticket keys. If the length

--- a/tls/common.go
+++ b/tls/common.go
@@ -1269,3 +1269,7 @@ func (config *Config) MarshalJSON() ([]byte, error) {
 func (config *Config) UnmarshalJSON(b []byte) error {
 	panic("unimplemented")
 }
+
+// Error type raised by doFullHandshake() when the CertsOnly option is
+// in use
+var ErrCertsOnly = errors.New("handshake abandoned per TLSCertsOnly option")

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,9 +515,10 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
-
-		return nil
-
+        if c.config.TLSCertsOnly {
+            // All done
+		    return nil
+        }
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -612,7 +613,6 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
 			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
 
-
 			// If actually verifying and invalid, reject
 			if !c.config.InsecureSkipVerify {
 				if err != nil {
@@ -670,7 +670,6 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	// If we don't support the cipher, quit before we need to read the hs.suite

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,10 +515,6 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
-		if c.config.CertsOnly {
-			// All done
-			return nil
-		}
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -589,7 +585,8 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 
 		if c.config.CertsOnly {
 			// short circuit!
-			return nil
+			err = ErrCertsOnly
+			return err
 		}
 
 		if !invalidCert {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -513,6 +513,9 @@ func (c *Conn) clientHandshake() error {
 		}
 	} else {
 		if err := hs.doFullHandshake(); err != nil {
+            if err == ErrCertsOnly {
+                c.sendAlert(alertCloseNotify)
+            }
 			return err
 		}
 		if err := hs.establishKeys(); err != nil {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -513,9 +513,9 @@ func (c *Conn) clientHandshake() error {
 		}
 	} else {
 		if err := hs.doFullHandshake(); err != nil {
-            if err == ErrCertsOnly {
-                c.sendAlert(alertCloseNotify)
-            }
+			if err == ErrCertsOnly {
+				c.sendAlert(alertCloseNotify)
+			}
 			return err
 		}
 		if err := hs.establishKeys(); err != nil {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,10 +515,10 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
-        if c.config.TLSCertsOnly {
-            // All done
-		    return nil
-        }
+		if c.config.TLSCertsOnly {
+			// All done
+			return nil
+		}
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -588,8 +588,8 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 
 		if c.config.TLSCertsOnly {
-		  // short circuit!
-  		  return nil
+			// short circuit!
+			return nil
 		}
 
 		if !invalidCert {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -592,7 +592,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			return err
 		}
 
-		if !c.config.SkipValidation {
+		if !c.config.InsecureSkipValidation {
 			if !invalidCert {
 				opts := x509.VerifyOptions{
 					Roots:         c.config.RootCAs,

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,6 +515,9 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
+
+		return nil
+
 		if err := hs.establishKeys(); err != nil {
 			return err
 		}
@@ -583,6 +586,11 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 
 		c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 
+		if c.config.TLSCertsOnly {
+		  // short circuit!
+  		  return nil
+		}
+
 		if !invalidCert {
 			opts := x509.VerifyOptions{
 				Roots:         c.config.RootCAs,
@@ -603,6 +611,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			var validation *x509.Validation
 			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
 			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
+
 
 			// If actually verifying and invalid, reject
 			if !c.config.InsecureSkipVerify {
@@ -661,6 +670,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		if err != nil {
 			return err
 		}
+
 	}
 
 	// If we don't support the cipher, quit before we need to read the hs.suite

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -515,7 +515,7 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.doFullHandshake(); err != nil {
 			return err
 		}
-		if c.config.TLSCertsOnly {
+		if c.config.CertsOnly {
 			// All done
 			return nil
 		}
@@ -587,7 +587,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 
 		c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 
-		if c.config.TLSCertsOnly {
+		if c.config.CertsOnly {
 			// short circuit!
 			return nil
 		}

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -592,39 +592,41 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			return err
 		}
 
-		if !invalidCert {
-			opts := x509.VerifyOptions{
-				Roots:         c.config.RootCAs,
-				CurrentTime:   c.config.time(),
-				DNSName:       c.config.ServerName,
-				Intermediates: x509.NewCertPool(),
-			}
+		if !c.config.SkipValidation {
+			if !invalidCert {
+				opts := x509.VerifyOptions{
+					Roots:         c.config.RootCAs,
+					CurrentTime:   c.config.time(),
+					DNSName:       c.config.ServerName,
+					Intermediates: x509.NewCertPool(),
+				}
 
-			// Always check validity of the certificates
-			for _, cert := range certs {
-				/*
-					if i == 0 {
-						continue
+				// Always check validity of the certificates
+				for _, cert := range certs {
+					/*
+						if i == 0 {
+							continue
+						}
+					*/
+					opts.Intermediates.AddCert(cert)
+				}
+				var validation *x509.Validation
+				c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
+				c.handshakeLog.ServerCertificates.addParsed(certs, validation)
+
+				// If actually verifying and invalid, reject
+				if !c.config.InsecureSkipVerify {
+					if err != nil {
+						c.sendAlert(alertBadCertificate)
+						return err
 					}
-				*/
-				opts.Intermediates.AddCert(cert)
-			}
-			var validation *x509.Validation
-			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
-			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
-
-			// If actually verifying and invalid, reject
-			if !c.config.InsecureSkipVerify {
-				if err != nil {
-					c.sendAlert(alertBadCertificate)
-					return err
 				}
 			}
-		}
 
-		if invalidCert {
-			c.sendAlert(alertBadCertificate)
-			return errors.New("tls: failed to parse certificate from server: " + invalidCertErr.Error())
+			if invalidCert {
+				c.sendAlert(alertBadCertificate)
+				return errors.New("tls: failed to parse certificate from server: " + invalidCertErr.Error())
+			}
 		}
 
 		c.peerCertificates = certs


### PR DESCRIPTION
This PR is a follow up on PR #100, which introduced the ability to early-abort the handshake.  One drawback of the early abort is that it can create noise in the logs of servers with verbose logging.

The option introduced in this PR "SkipValidation", allows a user to skip all validation and parsing of the certificate chain (for speed, the use case is for post-processing offline), while still finishing the handshake cleanly.

My early testing suggests this is about 2x slower than --certs-only, but still about 4--5x faster than the default behavior.