### PR TITLE
zcrypto/tls: buffer handshake messages

### DIFF
--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -493,7 +493,7 @@ func (c *Conn) clientHandshake() error {
 	if err != nil {
 		return err
 	}
-
+	c.buffering = true
 	if isResume {
 		if c.cipherError != nil {
 			c.sendAlert(alertHandshakeFailure)
@@ -511,6 +511,9 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.sendFinished(); err != nil {
 			return err
 		}
+		if _, err := c.flush(); err != nil {
+			return err
+		}
 	} else {
 		if err := hs.doFullHandshake(); err != nil {
 			if err == ErrCertsOnly {
@@ -522,6 +525,9 @@ func (c *Conn) clientHandshake() error {
 			return err
 		}
 		if err := hs.sendFinished(); err != nil {
+			return err
+		}
+		if _, err := c.flush(); err != nil {
 			return err
 		}
 		if err := hs.readSessionTicket(); err != nil {


### PR DESCRIPTION
Backports most of https://github.com/golang/go/commit/2a8c81ffaadc69add6ff85b241691adb7f9f24ff

The only differences should be the following omissions
 1. the change involving `Conn.bytesSent`, which we don't track, and
 2. the `TestFailedWrite` change, since we don't have the `TestFailedWrite` test

## How to Test

The included unit tests do work; you can also use Wireshark etc to confirm that fewer packets get sent in the handshake.

The only place I have seen different behavior is with MSSQL, but getting to that point is non-trivial.

## Notes & Caveats

There is another feature branch where this can be disabled using a `tls.Config.DontBufferHandshakes` flag (https://github.com/zmap/zcrypto/compare/feature/bufferHandshakes...feature/gatedBufferHandshakes). I kept these separate so that the backported commit would be isolated.

## Issue Tracking

Pre-requisite for https://github.com/zmap/zgrab2/issues/18

