### PR TITLE
tls: add tls.Config option to disable buffered handshakes

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -500,6 +500,9 @@ type Config struct {
 	// as soon as the server's certificates have been received
 	CertsOnly bool
 
+	// DontBufferHandshakes causes Handshake() to act like older versions of the go crypto library, where each TLS packet is sent in a separate Write.
+	DontBufferHandshakes bool
+
 	// mutex protects sessionTicketKeys and originalConfig.
 	mutex sync.RWMutex
 	// sessionTicketKeys contains zero or more ticket keys. If the length
@@ -1224,6 +1227,7 @@ type ConfigJSON struct {
 	ClientRandom                   []byte                          `json:"client_random,omitempty"`
 	ExternalClientHello            []byte                          `json:"external_client_hello,omitempty"`
 	ClientFingerprintConfiguration *ClientFingerprintConfiguration `json:"client_fingerprint_config,omitempty"`
+	DontBufferHandshakes           bool                            `json:"dont_buffer_handshakes"`
 }
 
 func (config *Config) MarshalJSON() ([]byte, error) {
@@ -1262,6 +1266,7 @@ func (config *Config) MarshalJSON() ([]byte, error) {
 	aux.ClientRandom = config.ClientRandom
 	aux.ExternalClientHello = config.ExternalClientHello
 	aux.ClientFingerprintConfiguration = config.ClientFingerprintConfiguration
+	aux.DontBufferHandshakes = config.DontBufferHandshakes
 
 	return json.Marshal(aux)
 }

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -495,6 +495,7 @@ func (c *Conn) clientHandshake() error {
 	}
 	if !c.config.DontBufferHandshakes {
 		c.buffering = true
+		defer c.flush()
 	}
 	if isResume {
 		if c.cipherError != nil {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -493,7 +493,7 @@ func (c *Conn) clientHandshake() error {
 	if err != nil {
 		return err
 	}
-
+	c.buffering = true
 	if isResume {
 		if c.cipherError != nil {
 			c.sendAlert(alertHandshakeFailure)
@@ -511,6 +511,9 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.sendFinished(); err != nil {
 			return err
 		}
+		if _, err := c.flush(); err != nil {
+			return err
+		}
 	} else {
 		if err := hs.doFullHandshake(); err != nil {
 			if err == ErrCertsOnly {
@@ -522,6 +525,9 @@ func (c *Conn) clientHandshake() error {
 			return err
 		}
 		if err := hs.sendFinished(); err != nil {
+			return err
+		}
+		if _, err := c.flush(); err != nil {
 			return err
 		}
 		if err := hs.readSessionTicket(); err != nil {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -493,7 +493,9 @@ func (c *Conn) clientHandshake() error {
 	if err != nil {
 		return err
 	}
-	c.buffering = true
+	if !c.config.DontBufferHandshakes {
+		c.buffering = true
+	}
 	if isResume {
 		if c.cipherError != nil {
 			c.sendAlert(alertHandshakeFailure)

--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -52,6 +52,7 @@ func (c *Conn) serverHandshake() error {
 	// For an overview of TLS handshaking, see https://tools.ietf.org/html/rfc5246#section-7.3
 	if !c.config.DontBufferHandshakes {
 		c.buffering = true
+		defer c.flush()
 	}
 	if isResume {
 		// The client has included a session ticket and so we do an abbreviated handshake.
@@ -85,6 +86,7 @@ func (c *Conn) serverHandshake() error {
 		}
 		if !c.config.DontBufferHandshakes {
 			c.buffering = true
+			defer c.flush()
 		}
 		if err := hs.sendSessionTicket(); err != nil {
 			return err

--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -50,7 +50,9 @@ func (c *Conn) serverHandshake() error {
 	}
 
 	// For an overview of TLS handshaking, see https://tools.ietf.org/html/rfc5246#section-7.3
-	c.buffering = true
+	if !c.config.DontBufferHandshakes {
+		c.buffering = true
+	}
 	if isResume {
 		// The client has included a session ticket and so we do an abbreviated handshake.
 		if err := hs.doResumeHandshake(); err != nil {
@@ -81,7 +83,9 @@ func (c *Conn) serverHandshake() error {
 		if err := hs.readFinished(); err != nil {
 			return err
 		}
-		c.buffering = true
+		if !c.config.DontBufferHandshakes {
+			c.buffering = true
+		}
 		if err := hs.sendSessionTicket(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds a `DontBufferHandshakes` tls.Config option. Setting this to `true` reverts to the prior behavior, where each handshake packet is sent in its own `conn.Write()`.

## How to Test

The included unit tests do work; you can also use Wireshark etc to confirm that more packets get sent in the handshake when `DontBufferHandshakes = true`.

The only place I have seen different behavior is with MSSQL, but getting to that point is non-trivial.

## Notes & Caveats

I didn't see any other examples of a default-true config option; the double negative `DontBufferHandshakes = false` isn't ideal, but it at least seemed clearer than e.g. `SendUnbufferedHandshakes = false`.

Also ensures that the buffers get flushed on a panic.

## Issue Tracking

Pre-requisite for https://github.com/zmap/zgrab2/issues/18

