### PR TITLE
key_agreement.go: Fix segmentation violation runtime error on failed cast

### DIFF
--- a/tls/key_agreement.go
+++ b/tls/key_agreement.go
@@ -457,10 +457,10 @@ func (ka *signedKeyAgreement) verifyParameters(config *Config, clientHello *clie
 	switch ka.sigType {
 	case signatureECDSA:
 		augECDSA, ok := cert.PublicKey.(*x509.AugmentedECDSA)
-		pubKey := augECDSA.Pub
 		if !ok {
 			return errors.New("ECDHE ECDSA: could not covert cert.PublicKey to x509.AugmentedECDSA")
 		}
+		pubKey := augECDSA.Pub
 		ecdsaSig := new(ecdsaSignature)
 		if _, err := asn1.Unmarshal(sig, ecdsaSig); err != nil {
 			return err


### PR DESCRIPTION
Don't index augECDSA until confirming that the cast succeeded.

Should address this: https://ichnaea.eecs.umich.edu/admin/tasks/a47e2ae2-4f47-4ae4-86da-b8cc3a85a5c9

