### PR TITLE
don't set C.CFDataRef explicitly to nil for darwin

### DIFF
--- a/ct/x509/root_darwin.go
+++ b/ct/x509/root_darwin.go
@@ -70,7 +70,7 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
 func initSystemRoots() {
 	roots := NewCertPool()
 
-	var data C.CFDataRef = nil
+	var data C.CFDataRef
 	err := C.FetchPEMRootsCTX509(&data)
 	if err == -1 {
 		return

--- a/x509/root_cgo_darwin.go
+++ b/x509/root_cgo_darwin.go
@@ -97,7 +97,7 @@ import (
 func loadSystemRoots() (*CertPool, error) {
 	roots := NewCertPool()
 
-	var data C.CFDataRef = nil
+	var data C.CFDataRef
 	err := C.ZToolsFetchPEMRoots(&data)
 	if err == -1 {
 		// TODO: better error message


### PR DESCRIPTION
A much smaller fix to https://github.com/zmap/zcrypto/issues/106. I was trying out `zcertificate` and ran into the same problem. 