### PR TITLE
Add InsecureSkipValidation option

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -389,6 +389,11 @@ type Config struct {
 	// This should be used only for testing.
 	InsecureSkipVerify bool
 
+	// InsecureSkipValidation, is like InsecureSkipVerify is used to skip
+	// even attempting to validate the certificate.
+	// Useful for offline processing of scanning results.
+	InsecureSkipValidation bool
+
 	// CipherSuites is a list of supported cipher suites. If CipherSuites
 	// is nil, TLS uses a list of suites supported by the implementation.
 	CipherSuites []uint16
@@ -1207,6 +1212,7 @@ type ConfigJSON struct {
 	ClientAuth                     ClientAuthType                  `json:"client_auth_type"`
 	ClientCAs                      *x509.CertPool                  `json:"client_cas,omitempty"`
 	InsecureSkipVerify             bool                            `json:"skip_verify"`
+	InsecureSkipValidation         bool                            `json:"skip_validation"`
 	CipherSuites                   []CipherSuite                   `json:"cipher_suites,omitempty"`
 	PreferServerCipherSuites       bool                            `json:"prefer_server_cipher_suites"`
 	SessionTicketsDisabled         bool                            `json:"session_tickets_disabled"`
@@ -1240,6 +1246,7 @@ func (config *Config) MarshalJSON() ([]byte, error) {
 	aux.ClientAuth = config.ClientAuth
 	aux.ClientCAs = config.ClientCAs
 	aux.InsecureSkipVerify = config.InsecureSkipVerify
+	aux.InsecureSkipValidation = config.InsecureSkipValidation
 
 	ciphers := config.cipherSuites()
 	aux.CipherSuites = make([]CipherSuite, len(ciphers))

--- a/tls/common.go
+++ b/tls/common.go
@@ -389,8 +389,8 @@ type Config struct {
 	// This should be used only for testing.
 	InsecureSkipVerify bool
 
-	// InsecureSkipValidation, is like InsecureSkipVerify is used to skip
-	// even attempting to validate the certificate.
+	// InsecureSkipValidation is like InsecureSkipVerify but it skips even
+	// attempting to validate the certificate.
 	// Useful for offline processing of scanning results.
 	InsecureSkipValidation bool
 

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -601,32 +601,34 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			return err
 		}
 
-		if !invalidCert {
-			opts := x509.VerifyOptions{
-				Roots:         c.config.RootCAs,
-				CurrentTime:   c.config.time(),
-				DNSName:       c.config.ServerName,
-				Intermediates: x509.NewCertPool(),
-			}
+		if !c.config.InsecureSkipValidation {
+			if !invalidCert {
+				opts := x509.VerifyOptions{
+					Roots:         c.config.RootCAs,
+					CurrentTime:   c.config.time(),
+					DNSName:       c.config.ServerName,
+					Intermediates: x509.NewCertPool(),
+				}
 
-			// Always check validity of the certificates
-			for _, cert := range certs {
-				/*
-					if i == 0 {
-						continue
+				// Always check validity of the certificates
+				for _, cert := range certs {
+					/*
+						if i == 0 {
+							continue
+						}
+					*/
+					opts.Intermediates.AddCert(cert)
+				}
+				var validation *x509.Validation
+				c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
+				c.handshakeLog.ServerCertificates.addParsed(certs, validation)
+
+				// If actually verifying and invalid, reject
+				if !c.config.InsecureSkipVerify {
+					if err != nil {
+						c.sendAlert(alertBadCertificate)
+						return err
 					}
-				*/
-				opts.Intermediates.AddCert(cert)
-			}
-			var validation *x509.Validation
-			c.verifiedChains, validation, err = certs[0].ValidateWithStupidDetail(opts)
-			c.handshakeLog.ServerCertificates.addParsed(certs, validation)
-
-			// If actually verifying and invalid, reject
-			if !c.config.InsecureSkipVerify {
-				if err != nil {
-					c.sendAlert(alertBadCertificate)
-					return err
 				}
 			}
 		}


### PR DESCRIPTION
Follows https://github.com/zmap/zcrypto/pull/103, except moves the check for `if invalidCert` out of the `if !c.InsecureSkipValidation` block, so that the handshake is not attempted with a certificate that fails to parse (which is `invalid` in the sense of not being valid X.509, not the sense of not successfully path-validated).

**Note**: The original comments on `InsecureSkipValidation` indicated that the certificate was not even parsed -- this is not accurate, since the certificate must be parsed in order to complete the handshake.  This has been updated to reflect that here no validation is attempted.

