### PR TITLE
pull ztools from zgrab

### DIFF
--- a/tls/generate_cert.go
+++ b/tls/generate_cert.go
@@ -13,8 +13,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 
-	"github.com/zmap/ztools/x509"
-	"github.com/zmap/ztools/x509/pkix"
+	"github.com/zmap/zgrab/ztools/x509"
+	"github.com/zmap/zgrab/ztools/x509/pkix"
 
 	"encoding/pem"
 	"flag"


### PR DESCRIPTION
This is causing `go dep` on zgrab to fail.

The fact that this is an explicit dependency on zgrab from zcrypto is problematic, but since it's a main file it shouldn't cause any problems.