### PR TITLE
Pull x509 and x509/pkix from zcrypto

### DIFF
--- a/tls/generate_cert.go
+++ b/tls/generate_cert.go
@@ -13,8 +13,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 
-	"github.com/zmap/zgrab/ztools/x509"
-	"github.com/zmap/zgrab/ztools/x509/pkix"
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zcrypto/x509/pkix"
 
 	"encoding/pem"
 	"flag"


### PR DESCRIPTION
ztools may be in zgrab, but x509/pkix is not in ztools.

`go build generate_cert.go` works now.