### PR TITLE
Handle multiple aliases per CRL DistributionPointName

### DIFF
--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -1044,13 +1044,20 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 
 				for _, dp := range cdp {
 					var n asn1.RawValue
-					_, err = asn1.Unmarshal(dp.DistributionPoint.FullName.Bytes, &n)
-					if err != nil {
-						return nil, err
-					}
-
-					if n.Tag == 6 {
-						out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+					dpName := dp.DistributionPoint.FullName.Bytes
+					// FullName is a GeneralNames, which is a SEQUENCE OF
+					// GeneralName, which in turn is a CHOICE.
+					// Per https://www.ietf.org/rfc/rfc5280.txt, multiple names
+					// for a single DistributionPoint give different pointers to
+					// the same CRL.
+					for len(dpName) > 0 {
+						dpName, err = asn1.Unmarshal(dpName, &n)
+						if err != nil {
+							return nil, err
+						}
+						if n.Tag == 6 {
+							out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+						}
 					}
 				}
 				continue

--- a/x509/x509_modified.go
+++ b/x509/x509_modified.go
@@ -1041,13 +1041,20 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 					}
 
 					var n asn1.RawValue
-					_, err = asn1.Unmarshal(dp.DistributionPoint.FullName.Bytes, &n)
-					if err != nil {
-						return nil, err
-					}
-
-					if n.Tag == 6 {
-						out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+					dpName := dp.DistributionPoint.FullName.Bytes
+					// FullName is a GeneralNames, which is a SEQUENCE OF
+					// GeneralName, which in turn is a CHOICE.
+					// Per https://www.ietf.org/rfc/rfc5280.txt, multiple names
+					// for a single DistributionPoint give different pointers to
+					// the same CRL.
+					for len(dpName) > 0 {
+						dpName, err = asn1.Unmarshal(dpName, &n)
+						if err != nil {
+							return nil, err
+						}
+						if n.Tag == 6 {
+							out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+						}
 					}
 				}
 				continue


### PR DESCRIPTION
Walk through the entire fullName in the DistributionPointNames, and add each URI entry to the CRLDPs slice (re https://github.com/zmap/zlint/issues/223).