### PR TITLE
[CEN-597] Fixes minimum timestamp for clamping to use UNIX epoch

### DIFF
--- a/x509/json.go
+++ b/x509/json.go
@@ -24,7 +24,7 @@ var kMinTime, kMaxTime time.Time
 
 func init() {
 	var err error
-	kMinTime, err = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
+	kMinTime, err = time.Parse(time.RFC3339, "1970-01-01T00:00:00Z")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
https://censysio.atlassian.net/browse/CEN-597