### PR TITLE
Fix panic() in ct/x509/x509.go

### DIFF
--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -1137,7 +1137,7 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 				}
 			}
 		} else if e.Id.Equal(oidExtensionCTPrecertificatePoison) {
-			if e.Value[0] == 5 && e.Value[1] == 0 {
+			if len(e.Value) >= 2 && e.Value[0] == 5 && e.Value[1] == 0 {
 				out.IsPrecert = true
 				continue
 			} else {


### PR DESCRIPTION
Add missing length check when reading the poison extension