### PR TITLE
Update OCSP Request Constructor

### DIFF
--- a/x509/revocation/ocsp/ocsp.go
+++ b/x509/revocation/ocsp/ocsp.go
@@ -5,7 +5,6 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"errors"
-	"hash"
 	"math/big"
 	"time"
 
@@ -104,37 +103,29 @@ type PublicKeyInfo struct {
 	PublicKey asn1.BitString
 }
 
-// GetKeyHash - compute hash of the certificate's public key, using
-// the specified hash algorithm
-func GetKeyHash(cert *x509.Certificate, hInstance hash.Hash) ([]byte, error) {
-	hInstance.Reset()
+// GetKeyHashSHA1 - compute hash of the certificate's public key, using SHA-1
+func GetKeyHashSHA1(cert *x509.Certificate) ([]byte, error) {
+	hashFunc := crypto.SHA1
+	h := hashFunc.New()
 	var keyInfo PublicKeyInfo
 	if _, err := asn1.Unmarshal(cert.RawSubjectPublicKeyInfo, &keyInfo); err != nil {
 		return nil, err
 	}
-	hInstance.Write(keyInfo.PublicKey.RightAlign())
-	return hInstance.Sum(nil), nil
+	h.Write(keyInfo.PublicKey.RightAlign())
+	return h.Sum(nil), nil
 }
 
-// GetNameHash - compute hash of the certificate's subject field, using
-// the specified hash algorithm
-func GetNameHash(cert *x509.Certificate, hInstance hash.Hash) []byte {
-	hInstance.Reset()
-	hInstance.Write(cert.RawSubject)
-	return hInstance.Sum(nil)
+// GetNameHashSHA1 - compute hash of the certificate's subject field, using SHA-1
+func GetNameHashSHA1(cert *x509.Certificate) []byte {
+	hashFunc := crypto.SHA1
+	h := hashFunc.New()
+	h.Write(cert.RawSubject)
+	return h.Sum(nil)
 }
 
 // CreateRequest returns a DER-encoded, OCSP request for the status of cert
-func CreateRequest(cert *x509.Certificate, issuer *x509.Certificate) ([]byte, error) {
-	hashFunc := crypto.SHA1
-	h := hashFunc.New()
-	issuerKeyHash, err := GetKeyHash(issuer, h)
-	if err != nil {
-		return nil, err
-	}
-
-	issuerNameHash := GetNameHash(issuer, h)
-
+// keyhash and namehash must be computed with SHA-1, use functions above
+func CreateRequest(cert *x509.Certificate, issuerKeyHash []byte, issuerNameHash []byte) ([]byte, error) {
 	sha1HashOID := asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
 	algID := &pkix.AlgorithmIdentifier{
 		Algorithm:  sha1HashOID,

--- a/x509/revocation/ocsp/ocsp.go
+++ b/x509/revocation/ocsp/ocsp.go
@@ -398,7 +398,9 @@ func ParseResponseForCert(bytes []byte, cert *x509.Certificate, issuer *x509.Cer
 		NextUpdate:         singleResp.NextUpdate,
 	}
 
-	ret.IsValidSignature = ValidateResponse(ret, basicResp, issuer)
+	if issuer != nil {
+		ret.IsValidSignature = ValidateResponse(ret, basicResp, issuer)
+	}
 
 	// Handle the ResponderID CHOICE tag. ResponderID can be flattened into
 	// TBSResponseData once https://go-review.googlesource.com/34503 has been

--- a/x509/revocation/ocsp/ocsp_test.go
+++ b/x509/revocation/ocsp/ocsp_test.go
@@ -147,7 +147,12 @@ func parseCertPEM(t *testing.T) (cert *x509.Certificate, revoked *x509.Certifica
 
 func TestOCSPCreateRequest(t *testing.T) {
 	cert, _, issuer := parseCertPEM(t)
-	requestBytes, err := ocsp.CreateRequest(cert, issuer)
+	issuerKeyHash, err := ocsp.GetKeyHashSHA1(issuer)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	issuerNameHash := ocsp.GetNameHashSHA1(issuer)
+	requestBytes, err := ocsp.CreateRequest(cert, issuerKeyHash, issuerNameHash)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -224,9 +229,9 @@ func TestStatusCode(t *testing.T) {
 }
 
 func TestBadIssuerHash(t *testing.T) {
-	cert, _, issuer := parseCertPEM(t)
+	_, _, issuer := parseCertPEM(t)
 	issuer.RawSubjectPublicKeyInfo = issuer.RawSubjectPublicKeyInfo[0:5] // mess up issuer key
-	_, err := ocsp.CreateRequest(cert, issuer)                           // this should fail when unmarshaling key
+	_, err := ocsp.GetKeyHashSHA1(issuer)                                // this should fail when unmarshaling key
 	if err == nil {
 		t.Fail()
 	}


### PR DESCRIPTION
Streamline the OCSP request creation function to only require
the two _specific_ pieces of information on the issuer needed (SPKI hash and
Subject hash), rather than requiring the _entire_ issuer certificate.

Should greatly improve scanning functionality, as scanning client no
longer needs to possess entire issuer cert.