### PR TITLE
s/INLCLUDE_RAW/ES_INCLUDE_RAW

### DIFF
--- a/zcrypto_schemas/zcrypto.py
+++ b/zcrypto_schemas/zcrypto.py
@@ -13,7 +13,7 @@ import zschema.registry
 # defined in ztag.
 class CensysString(WhitespaceAnalyzedString):
     "default type for any strings in Censys"
-    INCLUDE_RAW = True
+    ES_INCLUDE_RAW = True
 
 
 # Helper function for types where unknown values have a special value.


### PR DESCRIPTION
We set `INCLUDE_RAW` on our custom type. It should really be `ES_INCLUDE_RAW`. `INCLUDE_RAW` is not interpreted by ZSchema.