### PR TITLE
Backports from master to release/0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.4
+- 1.9.3
 install:
 - go get ./...
 - go get -t ./...

--- a/ct/types.go
+++ b/ct/types.go
@@ -297,7 +297,7 @@ type SignedCertificateTimestamp struct {
 	SCTVersion Version    `json:"version"` // The version of the protocol to which the SCT conforms
 	LogID      SHA256Hash `json:"log_id"`  // the SHA-256 hash of the log's public key, calculated over
 	// the DER encoding of the key represented as SubjectPublicKeyInfo.
-	Timestamp  uint64          `json:"timestamp,omitempty"`  // Timestamp (in ms since unix epoc) at which the SCT was issued
+	Timestamp  uint64          `json:"timestamp,omitempty"`  // Timestamp (in ms since unix epoc) at which the SCT was issued. NOTE: When this is serialized, the output is in seconds, not milliseconds.
 	Extensions CTExtensions    `json:"extensions,omitempty"` // For future extensions to the protocol
 	Signature  DigitallySigned `json:"signature"`            // The Log's signature for this SCT
 }

--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -1044,13 +1044,20 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 
 				for _, dp := range cdp {
 					var n asn1.RawValue
-					_, err = asn1.Unmarshal(dp.DistributionPoint.FullName.Bytes, &n)
-					if err != nil {
-						return nil, err
-					}
-
-					if n.Tag == 6 {
-						out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+					dpName := dp.DistributionPoint.FullName.Bytes
+					// FullName is a GeneralNames, which is a SEQUENCE OF
+					// GeneralName, which in turn is a CHOICE.
+					// Per https://www.ietf.org/rfc/rfc5280.txt, multiple names
+					// for a single DistributionPoint give different pointers to
+					// the same CRL.
+					for len(dpName) > 0 {
+						dpName, err = asn1.Unmarshal(dpName, &n)
+						if err != nil {
+							return nil, err
+						}
+						if n.Tag == 6 {
+							out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+						}
 					}
 				}
 				continue

--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -1130,7 +1130,7 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 				}
 			}
 		} else if e.Id.Equal(oidExtensionCTPrecertificatePoison) {
-			if e.Value[0] == 5 && e.Value[1] == 0 {
+			if len(e.Value) >= 2 && e.Value[0] == 5 && e.Value[1] == 0 {
 				out.IsPrecert = true
 				continue
 			} else {

--- a/tls/handshake_messages.go
+++ b/tls/handshake_messages.go
@@ -556,7 +556,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 			if length < 3 {
 				return false
 			}
-			exLen := int(data[0]<<8) | int(data[1])
+			exLen := int(data[0])<<8 | int(data[1])
 			if length != exLen+2 {
 				return false
 			}
@@ -931,7 +931,7 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 			if length < 3 {
 				return false
 			}
-			exRandLen := int(data[0]<<8) | int(data[1])
+			exRandLen := int(data[0])<<8 | int(data[1])
 			if length != exRandLen+2 {
 				return false
 			}

--- a/x509/extensions.go
+++ b/x509/extensions.go
@@ -33,8 +33,6 @@ var (
 	oidExtSignedCertificateTimestampList = oidExtensionSignedCertificateTimestampList
 )
 
-type encodedUnknownExtensions []encodedUnknownExtension
-
 type CertificateExtensions struct {
 	KeyUsage                       KeyUsage                         `json:"key_usage,omitempty"`
 	BasicConstraints               *BasicConstraints                `json:"basic_constraints,omitempty"`
@@ -52,12 +50,6 @@ type CertificateExtensions struct {
 }
 
 type UnknownCertificateExtensions []pkix.Extension
-
-type encodedUnknownExtension struct {
-	OID      string `json:"oid"`
-	Critical bool   `json:"critical"`
-	Value    []byte `json:"raw,omitempty"`
-}
 
 type IsPrecert bool
 


### PR DESCRIPTION
We're currently experiencing a data validation issue because zgrab1 uses an older release of zgrab, [`release/0.1`](https://github.com/zmap/zcrypto/tree/release/0.1).

The particular fix in question has been backported already in https://github.com/zmap/zcrypto/commit/d8354034948856c031f7d1625db598fa8c4260da , but zgrab hasn't been updated to use it yet.

This led me down a rabbit hole of tracking down other fixes on `master` which apply to `release/0.1` for zgrab1 as well.