### PR TITLE
Make JSON private types public

### DIFF
--- a/x509/json.go
+++ b/x509/json.go
@@ -212,7 +212,11 @@ func (v *validity) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type jsonSubjectKeyInfo struct {
+// JSONSubjectKeyInfo - used to condense several fields from x509.Certificate
+// related to the subject public key into one field within JSONCertificate
+// Unfortunately, this struct cannot have its own Marshal method since it
+// needs information from multiple fields in x509.Certificate
+type JSONSubjectKeyInfo struct {
 	KeyAlgorithm    PublicKeyAlgorithm     `json:"key_algorithm"`
 	RSAPublicKey    *jsonKeys.RSAPublicKey `json:"rsa_public_key,omitempty"`
 	DSAPublicKey    interface{}            `json:"dsa_public_key,omitempty"`
@@ -220,31 +224,44 @@ type jsonSubjectKeyInfo struct {
 	SPKIFingerprint CertificateFingerprint `json:"fingerprint_sha256"`
 }
 
-type jsonSignature struct {
+
+// JSONSignature - used to condense several fields from x509.Certificate
+// related to the signature into one field within JSONCertificate
+// Unfortunately, this struct cannot have its own Marshal method since it
+// needs information from multiple fields in x509.Certificate
+type JSONSignature struct {
 	SignatureAlgorithm SignatureAlgorithm `json:"signature_algorithm"`
 	Value              []byte             `json:"value"`
 	Valid              bool               `json:"valid"`
 	SelfSigned         bool               `json:"self_signed"`
 }
 
-type fullValidity struct {
+// JSONValidity - used to condense several fields related
+// to validity in x509.Certificate into one field within JSONCertificate
+// Unfortunately, this struct cannot have its own Marshal method since it
+// needs information from multiple fields in x509.Certificate
+type JSONValidity struct {
 	validity
 	ValidityPeriod int
 }
 
-type jsonCertificate struct {
+// JSONCertificate - used to condense data from x509.Certificate when marhsaling
+// into JSON. This struct has a distinct and independent layout from
+// x509.Certificate, mostly for condensing data across repetitive
+// fields and making it more presentable.
+type JSONCertificate struct {
 	Version                   int                          `json:"version"`
 	SerialNumber              string                       `json:"serial_number"`
 	SignatureAlgorithm        SignatureAlgorithm           `json:"signature_algorithm"`
 	Issuer                    pkix.Name                    `json:"issuer"`
 	IssuerDN                  string                       `json:"issuer_dn,omitempty"`
-	Validity                  fullValidity                 `json:"validity"`
+	Validity                  JSONValidity                 `json:"validity"`
 	Subject                   pkix.Name                    `json:"subject"`
 	SubjectDN                 string                       `json:"subject_dn,omitempty"`
-	SubjectKeyInfo            jsonSubjectKeyInfo           `json:"subject_key_info"`
+	SubjectKeyInfo            JSONSubjectKeyInfo           `json:"subject_key_info"`
 	Extensions                *CertificateExtensions       `json:"extensions,omitempty"`
 	UnknownExtensions         UnknownCertificateExtensions `json:"unknown_extensions,omitempty"`
-	Signature                 jsonSignature                `json:"signature"`
+	Signature                 JSONSignature                `json:"signature"`
 	FingerprintMD5            CertificateFingerprint       `json:"fingerprint_md5"`
 	FingerprintSHA1           CertificateFingerprint       `json:"fingerprint_sha1"`
 	FingerprintSHA256         CertificateFingerprint       `json:"fingerprint_sha256"`
@@ -278,7 +295,7 @@ func AddDSAPublicKeyToKeyMap(keyMap map[string]interface{}, key *dsa.PublicKey) 
 
 func (c *Certificate) MarshalJSON() ([]byte, error) {
 	// Fill out the certificate
-	jc := new(jsonCertificate)
+	jc := new(JSONCertificate)
 	jc.Version = c.Version
 	jc.SerialNumber = c.SerialNumber.String()
 	jc.SignatureAlgorithm = c.SignatureAlgorithm


### PR DESCRIPTION
Convert the private member types used in `jsonCertificate` into public types, which comments explaining why the exist and cannot be condensed or removed. (This is mostly because they have distinct and separate layout from the types in `x509.Certificate`, usually condensing multiple fields in `x509.Certificate` into single types).

Closes #170.