### PR TITLE
Add unmarshalers for certificates

### DIFF
--- a/x509/json.go
+++ b/x509/json.go
@@ -428,7 +428,7 @@ func (c *Certificate) UnmarshalJSON(b []byte) error {
 // The JSON output of Marshal is not even used to construct
 // a certificate, all we need is raw
 type JSONCertificateWithRaw struct {
-	Raw []byte
+	Raw []byte `json:"raw,omitempty"`
 }
 
 // ParseRaw - for converting the intermediate object

--- a/x509/json_test.go
+++ b/x509/json_test.go
@@ -70,6 +70,18 @@ func TestCertificateJSON(t *testing.T) {
 		if jsonString := string(jsonBytes); jsonString != test.expected {
 			t.Errorf("%d: expected %s, got %s", i, test.expected, jsonString)
 		}
+		backToCert := Certificate{}
+		err = json.Unmarshal(jsonBytes, &backToCert) // should fail
+		if err == nil {
+			t.Errorf("Expected UnmarshalJSON to fail, should not be used")
+		}
+		jsonWithRaw := JSONCertificateWithRaw{
+			Raw: p.Bytes,
+		}
+		_, err = jsonWithRaw.ParseRaw()
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
The `MarshalJSON` method on `x509.Certificate` condenses data in a way that is not recoverable. Given this situation, we can only fully reconstruct an `x509.Certificate` if we have the raw asn1 data. Therefore, the UnmarshalJSON methods on `x509.Certificate` and `x509.jsonCertificate` have been set to always error. A new type, `JSONCertificateWithRaw`, is introduced for parsing json that includes the raw asn1 cert data, from which a `x509.Certificate` can be constructed using the `x509.ParseCertificate` function.  

Closes #169, since all other Marshalers in `x509/json` have corresponding Unmarshalers. 
