### PR TITLE
 implement unmarshal interface for SignatureAndHash

### DIFF
--- a/tls/tls_ka.go
+++ b/tls/tls_ka.go
@@ -39,8 +39,9 @@ func (sh *SignatureAndHash) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
-	// TODO implement
-	panic("unimplemented")
+	sh.signature = signatureToName(aux.SignatureAlgorithm)
+	sh.hash = hashToName(aux.HashAlgorithm)
+	return nil
 }
 
 func (ka *rsaKeyAgreement) RSAParams() *jsonKeys.RSAPublicKey {

--- a/tls/tls_names.go
+++ b/tls/tls_names.go
@@ -4,7 +4,10 @@
 
 package tls
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 var signatureNames map[uint8]string
 var hashNames map[uint8]string
@@ -479,6 +482,26 @@ func nameForHash(h uint8) string {
 	}
 	num := strconv.Itoa(int(h))
 	return "unknown." + num
+}
+
+func signatureToName(n string) uint8 {
+	for k,v := range(signatureNames) {
+		if v == n {
+			return k
+		}
+	}
+	s,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 8)
+	return uint8(s)
+}
+
+func hashToName(n string) uint8 {
+	for k,v := range(hashNames) {
+		if v == n {
+			return k
+		}
+	}
+	h,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 8)
+	return uint8(h)
 }
 
 func nameForSuite(cs uint16) string {

--- a/tls/tls_names.go
+++ b/tls/tls_names.go
@@ -490,7 +490,7 @@ func signatureToName(n string) uint8 {
 			return k
 		}
 	}
-	s,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 8)
+	s,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 32)
 	return uint8(s)
 }
 
@@ -500,7 +500,7 @@ func hashToName(n string) uint8 {
 			return k
 		}
 	}
-	h,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 8)
+	h,_ := strconv.ParseInt(strings.TrimPrefix(n, "unknown."), 10, 32)
 	return uint8(h)
 }
 


### PR DESCRIPTION
I implement the unmarshal interface for SignatureAndHash. For reverse lookup from name to hash/signature, I just iterate through the maps. Since the numbers of items in the maps are super small, it should not affect the performance.