### PR TITLE
ci: use GOFLAGS, enforce gofmt -s.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,24 @@ go:
   - "1.11.x"
 
 env:
-  - GO111MODULE=on
+  - GO111MODULE="on" GOFLAGS="-mod=vendor"
 
 install:
-  - go install -mod=vendor -v ./...
+  - go install -v ./...
 
 script:
-  - go test -mod=vendor -v ./...
+  # Fast-fail on non-zero exit codes
+  - set -e
+  # Verify that all files have been gofmt'd with simplification.
+  #
+  # NOTE(@cpu): We use this `find` because Go issue 3197[0]
+  # and its many duplicates have yet to be resolved so we can't use `go fmt`
+  # without downloading copies of the already vendored deps.
+  #
+  # [0]: https://github.com/golang/go/issues/3197
+  - find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l
+  # Verify that unit tests pass
+  - go test -v ./...
 
 notifications:
   slack:


### PR DESCRIPTION
This PR sets up a global `GOFLAGS` to avoid needing to repeat it for each command.

It also changes the `script` to exit on the first error, and to enforce that all non-vendored `.go` files satisfy `gofmt -s` without diffs. This will make sure all code is consistently formatted and help contributors
do the right thing by default.