### PR TITLE
ci: switch from Go 1.11.x to 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11.x"
+  - "1.12.x"
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
1.12.x is the current stable release at the time of writing, and the Go version in use already for `zlint` CI.