### PR TITLE
CI: switch to Go 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 env:
-  - GO111MODULE="on" GOFLAGS="-mod=vendor"
+  - GOFLAGS="-mod=vendor"
 
 install:
   - go install -v ./...


### PR DESCRIPTION
Additionally remove `GO111MODULE=on` from the CI `env`, modules are on by default for Go 1.13.