### PR TITLE
Store multiple CN and SN values

### DIFF
--- a/x509/pkix/pkix.go
+++ b/x509/pkix/pkix.go
@@ -54,6 +54,7 @@ type Name struct {
 	StreetAddress, PostalCode, DomainComponent []string
 	EmailAddress                               []string
 	SerialNumber, CommonName                   string
+	SerialNumbers, CommonNames                 []string
 	GivenName, Surname                         []string
 	// EV Components
 	JurisdictionLocality, JurisdictionProvince, JurisdictionCountry []string
@@ -87,10 +88,12 @@ func (n *Name) FillFromRDNSequence(rdns *RDNSequence) {
 			switch t[3] {
 			case 3:
 				n.CommonName = value
+				n.CommonNames = append(n.CommonNames, value)
 			case 4:
 				n.Surname = append(n.Surname, value)
 			case 5:
 				n.SerialNumber = value
+				n.SerialNumbers = append(n.SerialNumbers, value)
 			case 6:
 				n.Country = append(n.Country, value)
 			case 7:


### PR DESCRIPTION
This PR stores multiple values from CN and Serial Number if multiple versions are present rather than simply overwriting with the last one. I'd certainly rather just turn those into arrays, but I don't want to break everything for a lint. 