### PR TITLE
tls: Export SignatureAndHash

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -219,15 +219,15 @@ const (
 	signatureECDSA uint8 = 3
 )
 
-// signatureAndHash mirrors the TLS 1.2, SignatureAndHashAlgorithm struct. See
+// SigAndHash mirrors the TLS 1.2, SignatureAndHashAlgorithm struct. See
 // RFC 5246, section A.4.1.
-type signatureAndHash struct {
-	signature, hash uint8
+type SigAndHash struct {
+	Signature, Hash uint8
 }
 
 // supportedSKXSignatureAlgorithms contains the signature and hash algorithms
 // that the code advertises as supported in a TLS 1.2 ClientHello.
-var supportedSKXSignatureAlgorithms = []signatureAndHash{
+var supportedSKXSignatureAlgorithms = []SigAndHash{
 	{signatureRSA, hashSHA512},
 	{signatureECDSA, hashSHA512},
 	{signatureDSA, hashSHA512},
@@ -248,7 +248,7 @@ var supportedSKXSignatureAlgorithms = []signatureAndHash{
 	{signatureDSA, hashMD5},
 }
 
-var defaultSKXSignatureAlgorithms = []signatureAndHash{
+var defaultSKXSignatureAlgorithms = []SigAndHash{
 	{signatureRSA, hashSHA256},
 	{signatureECDSA, hashSHA256},
 	{signatureRSA, hashSHA1},
@@ -258,7 +258,7 @@ var defaultSKXSignatureAlgorithms = []signatureAndHash{
 // supportedClientCertSignatureAlgorithms contains the signature and hash
 // algorithms that the code advertises as supported in a TLS 1.2
 // CertificateRequest.
-var supportedClientCertSignatureAlgorithms = []signatureAndHash{
+var supportedClientCertSignatureAlgorithms = []SigAndHash{
 	{signatureRSA, hashSHA256},
 	{signatureECDSA, hashSHA256},
 }
@@ -437,7 +437,7 @@ type Config struct {
 
 	// If enabled, specifies the signature and hash algorithms to be accepted by
 	// a server, or sent by a client
-	SignatureAndHashes []signatureAndHash
+	SignatureAndHashes []SigAndHash
 
 	serverInitOnce sync.Once // guards calling (*Config).serverInit
 
@@ -749,14 +749,14 @@ func (c *Config) getCertificateForName(name string) *Certificate {
 	return &c.Certificates[0]
 }
 
-func (c *Config) signatureAndHashesForServer() []signatureAndHash {
+func (c *Config) signatureAndHashesForServer() []SigAndHash {
 	if c != nil && c.SignatureAndHashes != nil {
 		return c.SignatureAndHashes
 	}
 	return supportedClientCertSignatureAlgorithms
 }
 
-func (c *Config) signatureAndHashesForClient() []signatureAndHash {
+func (c *Config) signatureAndHashesForClient() []SigAndHash {
 	if c != nil && c.SignatureAndHashes != nil {
 		return c.SignatureAndHashes
 	}
@@ -922,7 +922,7 @@ func unexpectedMessageError(wanted, got interface{}) error {
 	return fmt.Errorf("tls: received unexpected handshake message of type %T when waiting for %T", got, wanted)
 }
 
-func isSupportedSignatureAndHash(sigHash signatureAndHash, sigHashes []signatureAndHash) bool {
+func isSupportedSignatureAndHash(sigHash SigAndHash, sigHashes []SigAndHash) bool {
 	for _, s := range sigHashes {
 		if s == sigHash {
 			return true

--- a/tls/handshake_extensions.go
+++ b/tls/handshake_extensions.go
@@ -356,23 +356,23 @@ func (e *SignatureAlgorithmExtension) CheckImplemented() error {
 	for _, algs := range e.getStructuredAlgorithms() {
 		found := false
 		for _, supported := range supportedSKXSignatureAlgorithms {
-			if algs.hash == supported.hash && algs.signature == supported.signature {
+			if algs.Hash == supported.Hash && algs.Signature == supported.Signature {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return errors.New(fmt.Sprintf("Unsupported Hash and Signature Algorithm (%d, %d)", algs.hash, algs.signature))
+			return errors.New(fmt.Sprintf("Unsupported Hash and Signature Algorithm (%d, %d)", algs.Hash, algs.Signature))
 		}
 	}
 	return nil
 }
 
-func (e *SignatureAlgorithmExtension) getStructuredAlgorithms() []signatureAndHash {
-	result := make([]signatureAndHash, len(e.SignatureAndHashes))
+func (e *SignatureAlgorithmExtension) getStructuredAlgorithms() []SigAndHash {
+	result := make([]SigAndHash, len(e.SignatureAndHashes))
 	for i, alg := range e.SignatureAndHashes {
-		result[i].hash = uint8(alg >> 8)
-		result[i].signature = uint8(alg)
+		result[i].Hash = uint8(alg >> 8)
+		result[i].Signature = uint8(alg)
 	}
 	return result
 }
@@ -386,8 +386,8 @@ func (e *SignatureAlgorithmExtension) Marshal() []byte {
 	result[4] = uint8((2 * len(e.SignatureAndHashes)) >> 8)
 	result[5] = uint8((2 * len(e.SignatureAndHashes)))
 	for i, pair := range e.getStructuredAlgorithms() {
-		result[6+2*i] = uint8(pair.hash)
-		result[7+2*i] = uint8(pair.signature)
+		result[6+2*i] = uint8(pair.Hash)
+		result[7+2*i] = uint8(pair.Signature)
 	}
 	return result
 }

--- a/tls/handshake_messages.go
+++ b/tls/handshake_messages.go
@@ -24,7 +24,7 @@ type clientHelloMsg struct {
 	supportedPoints       []uint8
 	ticketSupported       bool
 	sessionTicket         []uint8
-	signatureAndHashes    []signatureAndHash
+	signatureAndHashes    []SigAndHash
 	secureRenegotiation   bool
 	heartbeatEnabled      bool
 	heartbeatMode         uint8
@@ -278,8 +278,8 @@ func (m *clientHelloMsg) marshal() []byte {
 		z[1] = byte(l)
 		z = z[2:]
 		for _, sigAndHash := range m.signatureAndHashes {
-			z[0] = sigAndHash.hash
-			z[1] = sigAndHash.signature
+			z[0] = sigAndHash.Hash
+			z[1] = sigAndHash.Signature
 			z = z[2:]
 		}
 	}
@@ -511,10 +511,10 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 			}
 			n := l / 2
 			d := data[2:]
-			m.signatureAndHashes = make([]signatureAndHash, n)
+			m.signatureAndHashes = make([]SigAndHash, n)
 			for i := range m.signatureAndHashes {
-				m.signatureAndHashes[i].hash = d[0]
-				m.signatureAndHashes[i].signature = d[1]
+				m.signatureAndHashes[i].Hash = d[0]
+				m.signatureAndHashes[i].Signature = d[1]
 				d = d[2:]
 			}
 		case extensionRenegotiationInfo:
@@ -1350,7 +1350,7 @@ type certificateRequestMsg struct {
 	hasSignatureAndHash bool
 
 	certificateTypes       []byte
-	signatureAndHashes     []signatureAndHash
+	signatureAndHashes     []SigAndHash
 	certificateAuthorities [][]byte
 }
 
@@ -1400,8 +1400,8 @@ func (m *certificateRequestMsg) marshal() (x []byte) {
 		y[1] = uint8(n)
 		y = y[2:]
 		for _, sigAndHash := range m.signatureAndHashes {
-			y[0] = sigAndHash.hash
-			y[1] = sigAndHash.signature
+			y[0] = sigAndHash.Hash
+			y[1] = sigAndHash.Signature
 			y = y[2:]
 		}
 	}
@@ -1459,10 +1459,10 @@ func (m *certificateRequestMsg) unmarshal(data []byte) bool {
 			return false
 		}
 		numSigAndHash := sigAndHashLen / 2
-		m.signatureAndHashes = make([]signatureAndHash, numSigAndHash)
+		m.signatureAndHashes = make([]SigAndHash, numSigAndHash)
 		for i := range m.signatureAndHashes {
-			m.signatureAndHashes[i].hash = data[0]
-			m.signatureAndHashes[i].signature = data[1]
+			m.signatureAndHashes[i].Hash = data[0]
+			m.signatureAndHashes[i].Signature = data[1]
 			data = data[2:]
 		}
 	}
@@ -1504,7 +1504,7 @@ func (m *certificateRequestMsg) unmarshal(data []byte) bool {
 type certificateVerifyMsg struct {
 	raw                 []byte
 	hasSignatureAndHash bool
-	signatureAndHash    signatureAndHash
+	signatureAndHash    SigAndHash
 	signature           []byte
 }
 
@@ -1516,8 +1516,8 @@ func (m *certificateVerifyMsg) equal(i interface{}) bool {
 
 	return bytes.Equal(m.raw, m1.raw) &&
 		m.hasSignatureAndHash == m1.hasSignatureAndHash &&
-		m.signatureAndHash.hash == m1.signatureAndHash.hash &&
-		m.signatureAndHash.signature == m1.signatureAndHash.signature &&
+		m.signatureAndHash.Hash == m1.signatureAndHash.Hash &&
+		m.signatureAndHash.Signature == m1.signatureAndHash.Signature &&
 		bytes.Equal(m.signature, m1.signature)
 }
 
@@ -1539,8 +1539,8 @@ func (m *certificateVerifyMsg) marshal() (x []byte) {
 	x[3] = uint8(length)
 	y := x[4:]
 	if m.hasSignatureAndHash {
-		y[0] = m.signatureAndHash.hash
-		y[1] = m.signatureAndHash.signature
+		y[0] = m.signatureAndHash.Hash
+		y[1] = m.signatureAndHash.Signature
 		y = y[2:]
 	}
 	y[0] = uint8(siglength >> 8)
@@ -1566,8 +1566,8 @@ func (m *certificateVerifyMsg) unmarshal(data []byte) bool {
 
 	data = data[4:]
 	if m.hasSignatureAndHash {
-		m.signatureAndHash.hash = data[0]
-		m.signatureAndHash.signature = data[1]
+		m.signatureAndHash.Hash = data[0]
+		m.signatureAndHash.Signature = data[1]
 		data = data[2:]
 	}
 
@@ -1705,13 +1705,13 @@ func eqByteSlices(x, y [][]byte) bool {
 	return true
 }
 
-func eqSignatureAndHashes(x, y []signatureAndHash) bool {
+func eqSignatureAndHashes(x, y []SigAndHash) bool {
 	if len(x) != len(y) {
 		return false
 	}
 	for i, v := range x {
 		v2 := y[i]
-		if v.hash != v2.hash || v.signature != v2.signature {
+		if v.Hash != v2.Hash || v.Signature != v2.Signature {
 			return false
 		}
 	}

--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -478,7 +478,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		}
 
 		// Determine the signature type.
-		var signatureAndHash signatureAndHash
+		var signatureAndHash SigAndHash
 		if certVerify.hasSignatureAndHash {
 			signatureAndHash = certVerify.signatureAndHash
 			if !isSupportedSignatureAndHash(signatureAndHash, c.config.signatureAndHashesForServer()) {
@@ -490,15 +490,15 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 			// algorithm was possible. Leave the hash as zero.
 			switch pub.(type) {
 			case *ecdsa.PublicKey:
-				signatureAndHash.signature = signatureECDSA
+				signatureAndHash.Signature = signatureECDSA
 			case *rsa.PublicKey:
-				signatureAndHash.signature = signatureRSA
+				signatureAndHash.Signature = signatureRSA
 			}
 		}
 
 		switch key := pub.(type) {
 		case *x509.AugmentedECDSA:
-			if signatureAndHash.signature != signatureECDSA {
+			if signatureAndHash.Signature != signatureECDSA {
 				err = errors.New("tls: bad signature type for client's ECDSA certificate")
 				break
 			}
@@ -520,7 +520,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 				break
 			}
 		case *ecdsa.PublicKey:
-			if signatureAndHash.signature != signatureECDSA {
+			if signatureAndHash.Signature != signatureECDSA {
 				err = errors.New("tls: bad signature type for client's ECDSA certificate")
 				break
 			}
@@ -542,7 +542,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 				break
 			}
 		case *rsa.PublicKey:
-			if signatureAndHash.signature != signatureRSA {
+			if signatureAndHash.Signature != signatureRSA {
 				err = errors.New("tls: bad signature type for client's RSA certificate")
 				break
 			}
@@ -808,7 +808,7 @@ func (hs *serverHandshakeState) clientHelloInfo() *ClientHelloInfo {
 
 	signatureSchemes := make([]SignatureScheme, 0, len(hs.clientHello.signatureAndHashes))
 	for _, sah := range hs.clientHello.signatureAndHashes {
-		signatureSchemes = append(signatureSchemes, SignatureScheme(sah.hash)<<8+SignatureScheme(sah.signature))
+		signatureSchemes = append(signatureSchemes, SignatureScheme(sah.Hash)<<8+SignatureScheme(sah.Signature))
 	}
 
 	hs.cachedClientHelloInfo = &ClientHelloInfo{

--- a/tls/tls_ka.go
+++ b/tls/tls_ka.go
@@ -13,9 +13,9 @@ import (
 	jsonKeys "github.com/zmap/zcrypto/json"
 )
 
-// SignatureAndHash is a signatureAndHash that implements json.Marshaler and
+// SignatureAndHash is a SigAndHash that implements json.Marshaler and
 // json.Unmarshaler
-type SignatureAndHash signatureAndHash
+type SignatureAndHash SigAndHash
 
 type auxSignatureAndHash struct {
 	SignatureAlgorithm string `json:"signature_algorithm"`
@@ -25,8 +25,8 @@ type auxSignatureAndHash struct {
 // MarshalJSON implements the json.Marshaler interface
 func (sh *SignatureAndHash) MarshalJSON() ([]byte, error) {
 	aux := auxSignatureAndHash{
-		SignatureAlgorithm: nameForSignature(sh.signature),
-		HashAlgorithm:      nameForHash(sh.hash),
+		SignatureAlgorithm: nameForSignature(sh.Signature),
+		HashAlgorithm:      nameForHash(sh.Hash),
 	}
 	return json.Marshal(&aux)
 }
@@ -39,8 +39,8 @@ func (sh *SignatureAndHash) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
-	sh.signature = signatureToName(aux.SignatureAlgorithm)
-	sh.hash = hashToName(aux.HashAlgorithm)
+	sh.Signature = signatureToName(aux.SignatureAlgorithm)
+	sh.Hash = hashToName(aux.HashAlgorithm)
 	return nil
 }
 


### PR DESCRIPTION
The SignatureAndHashes field in tls.Config is exported, but the type signatureAndHashes is not, and neither are its fields.  Export this, and name is SigAndHashes to avoid conflict with the exported type
SignatureAndHashes in tls_ka.go.

With this exported, callers can override the supported SignatureAndHashes manually in their Config.

Note: This is an alternative approach to PR #222
Also, this does not export the signature or hash constants values.