### PR TITLE
CI: Fix `gofmt` Github Action.

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -5,10 +5,17 @@ jobs:
   build:
     name: Gofmt check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.14' ]
     steps:
 
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    # TODO(@cpu): Switch to v1.0.4 and add `gofmt-args: -l -s` once new release
+    # is available. See https://github.com/Jerome1337/gofmt-action/issues/5
     - name: Check gofmt
-      uses: Jerome1337/gofmt-action@v1.0.2
+      uses: Jerome1337/gofmt-action@v1.0.3
       with:
         gofmt-path: './'
-        args: '-l -s'


### PR DESCRIPTION
This updates the gofmt action added in https://github.com/zmap/zcrypto/pull/230 and fixes https://github.com/zmap/zcrypto/issues/232. A few changes:

1. Use the most recent version of the action published, add a note about updating to a new tag to support using `-s` with `gofmt` in the future. (See https://github.com/Jerome1337/gofmt-action/issues/5). In the meantime we can enforce `gofmt` without the `-s` mode.

2. Actually check out the code before trying to `gofmt` it. Otherwise everything will pass... This was my bad. I'm still getting adjusted to the Github actions way of doing things.

Verified this works correctly with [a branch](https://github.com/zmap/zcrypto/compare/master...cpu:cpu-gofmt-testing) on my fork. Here's the [failed Gofmt action run](https://github.com/cpu/zcrypto/runs/1444609999?check_suite_focus=true).