### PR TITLE
CI: update gofmt.yml workflow to restore `-s` arg.

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -13,9 +13,8 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    # TODO(@cpu): Switch to v1.0.4 and add `gofmt-args: -l -s` once new release
-    # is available. See https://github.com/Jerome1337/gofmt-action/issues/5
     - name: Check gofmt
-      uses: Jerome1337/gofmt-action@v1.0.3
+      uses: Jerome1337/gofmt-action@v1.0.4
       with:
         gofmt-path: './'
+        gofmt-flags: -l -s


### PR DESCRIPTION
In the Travis CI version of ZCrypto's integration tests the `gofmt` step used `-s` to enforce that files were all `gofmt`'d with "simplify code" enabled.

The Github action we're using for quick-n-easy `gofmt` checking has published a new tag that lets us specify custom `gofmt` args. This PR updates to that tag and adds the `-s` argument alongside `-l` to achieve parity with the removed Travis code.