### PR TITLE
URIs option missing from Name Constraints 

### DIFF
--- a/x509/extensions.go
+++ b/x509/extensions.go
@@ -209,6 +209,7 @@ type NameConstraints struct {
 
 	PermittedDNSNames       []GeneralSubtreeString
 	PermittedEmailAddresses []GeneralSubtreeString
+	PermittedURIs           []GeneralSubtreeString
 	PermittedIPAddresses    []GeneralSubtreeIP
 	PermittedDirectoryNames []GeneralSubtreeName
 	PermittedEdiPartyNames  []GeneralSubtreeEdi
@@ -216,6 +217,7 @@ type NameConstraints struct {
 
 	ExcludedEmailAddresses []GeneralSubtreeString
 	ExcludedDNSNames       []GeneralSubtreeString
+	ExcludedURIs           []GeneralSubtreeString
 	ExcludedIPAddresses    []GeneralSubtreeIP
 	ExcludedDirectoryNames []GeneralSubtreeName
 	ExcludedEdiPartyNames  []GeneralSubtreeEdi
@@ -227,6 +229,7 @@ type NameConstraintsJSON struct {
 
 	PermittedDNSNames       []string            `json:"permitted_names,omitempty"`
 	PermittedEmailAddresses []string            `json:"permitted_email_addresses,omitempty"`
+	PermittedURIs           []string            `json:"permitted_uris,omitempty"`
 	PermittedIPAddresses    []GeneralSubtreeIP  `json:"permitted_ip_addresses,omitempty"`
 	PermittedDirectoryNames []pkix.Name         `json:"permitted_directory_names,omitempty"`
 	PermittedEdiPartyNames  []pkix.EDIPartyName `json:"permitted_edi_party_names,omitempty"`
@@ -234,6 +237,7 @@ type NameConstraintsJSON struct {
 
 	ExcludedDNSNames       []string            `json:"excluded_names,omitempty"`
 	ExcludedEmailAddresses []string            `json:"excluded_email_addresses,omitempty"`
+	ExcludedURIs           []string            `json:"excluded_uris,omitempty"`
 	ExcludedIPAddresses    []GeneralSubtreeIP  `json:"excluded_ip_addresses,omitempty"`
 	ExcludedDirectoryNames []pkix.Name         `json:"excluded_directory_names,omitempty"`
 	ExcludedEdiPartyNames  []pkix.EDIPartyName `json:"excluded_edi_party_names,omitempty"`
@@ -251,6 +255,9 @@ func (nc *NameConstraints) UnmarshalJSON(b []byte) error {
 	}
 	for _, email := range ncJson.PermittedEmailAddresses {
 		nc.PermittedEmailAddresses = append(nc.PermittedEmailAddresses, GeneralSubtreeString{Data: email})
+	}
+	for _, uri := range ncJson.PermittedURIs {
+		nc.PermittedURIs = append(nc.PermittedURIs, GeneralSubtreeString{Data: uri})
 	}
 	for _, constraint := range ncJson.PermittedIPAddresses {
 		nc.PermittedIPAddresses = append(nc.PermittedIPAddresses, constraint)
@@ -280,6 +287,9 @@ func (nc *NameConstraints) UnmarshalJSON(b []byte) error {
 	}
 	for _, email := range ncJson.ExcludedEmailAddresses {
 		nc.ExcludedEmailAddresses = append(nc.ExcludedEmailAddresses, GeneralSubtreeString{Data: email})
+	}
+	for _, uri := range ncJson.ExcludedURIs {
+		nc.ExcludedURIs = append(nc.ExcludedURIs, GeneralSubtreeString{Data: uri})
 	}
 	for _, constraint := range ncJson.ExcludedIPAddresses {
 		nc.ExcludedIPAddresses = append(nc.ExcludedIPAddresses, constraint)
@@ -314,6 +324,9 @@ func (nc NameConstraints) MarshalJSON() ([]byte, error) {
 	for _, email := range nc.PermittedEmailAddresses {
 		out.PermittedEmailAddresses = append(out.PermittedEmailAddresses, email.Data)
 	}
+	for _, uri := range nc.PermittedURIs {
+		out.PermittedURIs = append(out.PermittedURIs, uri.Data)
+	}
 	out.PermittedIPAddresses = nc.PermittedIPAddresses
 	for _, directory := range nc.PermittedDirectoryNames {
 		out.PermittedDirectoryNames = append(out.PermittedDirectoryNames, directory.Data)
@@ -330,6 +343,9 @@ func (nc NameConstraints) MarshalJSON() ([]byte, error) {
 	}
 	for _, email := range nc.ExcludedEmailAddresses {
 		out.ExcludedEmailAddresses = append(out.ExcludedEmailAddresses, email.Data)
+	}
+	for _, uri := range nc.ExcludedURIs {
+		out.ExcludedURIs = append(out.ExcludedURIs, uri.Data)
 	}
 	for _, ip := range nc.ExcludedIPAddresses {
 		out.ExcludedIPAddresses = append(out.ExcludedIPAddresses, ip)
@@ -747,6 +763,7 @@ func (c *Certificate) jsonifyExtensions() (*CertificateExtensions, UnknownCertif
 
 			exts.NameConstraints.PermittedDNSNames = c.PermittedDNSNames
 			exts.NameConstraints.PermittedEmailAddresses = c.PermittedEmailAddresses
+			exts.NameConstraints.PermittedURIs = c.PermittedURIs
 			exts.NameConstraints.PermittedIPAddresses = c.PermittedIPAddresses
 			exts.NameConstraints.PermittedDirectoryNames = c.PermittedDirectoryNames
 			exts.NameConstraints.PermittedEdiPartyNames = c.PermittedEdiPartyNames
@@ -754,6 +771,7 @@ func (c *Certificate) jsonifyExtensions() (*CertificateExtensions, UnknownCertif
 
 			exts.NameConstraints.ExcludedEmailAddresses = c.ExcludedEmailAddresses
 			exts.NameConstraints.ExcludedDNSNames = c.ExcludedDNSNames
+			exts.NameConstraints.ExcludedURIs = c.ExcludedURIs
 			exts.NameConstraints.ExcludedIPAddresses = c.ExcludedIPAddresses
 			exts.NameConstraints.ExcludedDirectoryNames = c.ExcludedDirectoryNames
 			exts.NameConstraints.ExcludedEdiPartyNames = c.ExcludedEdiPartyNames

--- a/x509/extensions_test.go
+++ b/x509/extensions_test.go
@@ -375,13 +375,18 @@ func TestNameConstraintJSON(t *testing.T) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}
-		for _, e := range backToNC.ExcludedIPAddresses {
-			if !containsGeneralSubtreeIP(test.nc.ExcludedIPAddresses, e) {
+		for _, e := range backToNC.ExcludedEmailAddresses {
+			if !containsGeneralSubtreeString(test.nc.ExcludedEmailAddresses, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}
 		for _, e := range backToNC.ExcludedURIs {
 			if !containsGeneralSubtreeString(test.nc.ExcludedURIs, e) {
+				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
+			}
+		}
+		for _, e := range backToNC.ExcludedIPAddresses {
+			if !containsGeneralSubtreeIP(test.nc.ExcludedIPAddresses, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}

--- a/x509/extensions_test.go
+++ b/x509/extensions_test.go
@@ -228,6 +228,11 @@ func TestNameConstraintJSON(t *testing.T) {
 						Data: "test2@censys.io",
 					},
 				},
+				PermittedURIs: []GeneralSubtreeString{
+					{
+						Data: "http://www.example.com/foo/bar.html",
+					},
+				},
 				PermittedIPAddresses: []GeneralSubtreeIP{
 					{
 						Data: net.IPNet{IP: net.IPv4(127, 0, 0, 1), Mask: net.IPv4Mask(0, 0, 0, 0)},
@@ -340,6 +345,11 @@ func TestNameConstraintJSON(t *testing.T) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}
+		for _, e := range backToNC.PermittedURIs {
+			if !containsGeneralSubtreeString(test.nc.PermittedURIs, e) {
+				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
+			}
+		}
 		for _, e := range backToNC.PermittedIPAddresses {
 			if !containsGeneralSubtreeIP(test.nc.PermittedIPAddresses, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
@@ -365,13 +375,13 @@ func TestNameConstraintJSON(t *testing.T) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}
-		for _, e := range backToNC.ExcludedEmailAddresses {
-			if !containsGeneralSubtreeString(test.nc.ExcludedEmailAddresses, e) {
+		for _, e := range backToNC.ExcludedIPAddresses {
+			if !containsGeneralSubtreeIP(test.nc.ExcludedIPAddresses, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}
-		for _, e := range backToNC.ExcludedIPAddresses {
-			if !containsGeneralSubtreeIP(test.nc.ExcludedIPAddresses, e) {
+		for _, e := range backToNC.ExcludedURIs {
+			if !containsGeneralSubtreeString(test.nc.ExcludedURIs, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
 			}
 		}

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -785,6 +785,8 @@ type Certificate struct {
 	ExcludedDNSNames        []GeneralSubtreeString
 	PermittedEmailAddresses []GeneralSubtreeString
 	ExcludedEmailAddresses  []GeneralSubtreeString
+	PermittedURIs           []GeneralSubtreeString
+	ExcludedURIs            []GeneralSubtreeString
 	PermittedIPAddresses    []GeneralSubtreeIP
 	ExcludedIPAddresses     []GeneralSubtreeIP
 	PermittedDirectoryNames []GeneralSubtreeName
@@ -1656,6 +1658,8 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 							return out, err
 						}
 						out.PermittedEdiPartyNames = append(out.PermittedEdiPartyNames, GeneralSubtreeEdi{Data: ediName, Max: subtree.Max, Min: subtree.Min})
+					case 6:
+						out.PermittedURIs = append(out.PermittedURIs, GeneralSubtreeString{Data: string(subtree.Value.Bytes), Max: subtree.Max, Min: subtree.Min})
 					case 7:
 						switch len(subtree.Value.Bytes) {
 						case net.IPv4len * 2:
@@ -1699,6 +1703,8 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 							return out, err
 						}
 						out.ExcludedEdiPartyNames = append(out.ExcludedEdiPartyNames, GeneralSubtreeEdi{Data: ediName, Max: subtree.Max, Min: subtree.Min})
+					case 6:
+						out.ExcludedURIs = append(out.ExcludedURIs, GeneralSubtreeString{Data: string(subtree.Value.Bytes), Max: subtree.Max, Min: subtree.Min})
 					case 7:
 						switch len(subtree.Value.Bytes) {
 						case net.IPv4len * 2:


### PR DESCRIPTION
Hi!

I couldn't find an option to use URIs for name constraints inside x509.go, when it should be possible according to https://tools.ietf.org/html/rfc5280#section-4.2.1.10 .