### PR TITLE
project: switch to go 1.16.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/psl-update.yml
+++ b/.github/workflows/psl-update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Set current date
         id: get-date

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
-go 1.15
+go 1.16


### PR DESCRIPTION
[Go 1.16](https://golang.org/doc/go1.16) is the latest stable release. This PR switches the `go.mod` go version, as well as the version used in Github workflows for CI.