### PR TITLE
Use the internal DSA package throughout

### DIFF
--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -14,17 +14,21 @@ package x509
 import (
 	"bytes"
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/sha1"
+
+	"github.com/zmap/zcrypto/dsa"
+
 	// START CT CHANGES
 	"github.com/zmap/zcrypto/ct/asn1"
 	"github.com/zmap/zcrypto/ct/x509/pkix"
+
 	// END CT CHANGES
 	"encoding/pem"
 	"errors"
+
 	// START CT CHANGES
 	"fmt"
 	// END CT CHANGES

--- a/ct/x509/x509_test.go
+++ b/ct/x509/x509_test.go
@@ -6,26 +6,31 @@ package x509
 
 import (
 	"bytes"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
+
+	"github.com/zmap/zcrypto/dsa"
+
 	// START CT CHANGES
 	"github.com/zmap/zcrypto/ct/asn1"
 	"github.com/zmap/zcrypto/ct/x509/pkix"
+
 	// END CT CHANGES
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
+
 	// START CT CHANGES
 	"errors"
 	// END CT CHANGES
 	"math/big"
 	"net"
 	"reflect"
+
 	// START CT CHANGES
 	"strings"
 	// END CT CHANGES

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -6,7 +6,6 @@ package tls
 
 import (
 	"bytes"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/subtle"
@@ -19,6 +18,8 @@ import (
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/zmap/zcrypto/dsa"
 
 	"github.com/zmap/zcrypto/x509"
 )

--- a/tls/key_agreement.go
+++ b/tls/key_agreement.go
@@ -6,7 +6,6 @@ package tls
 
 import (
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/md5"
@@ -19,6 +18,8 @@ import (
 	"errors"
 	"io"
 	"math/big"
+
+	"github.com/zmap/zcrypto/dsa"
 
 	"github.com/zmap/zcrypto/x509"
 )

--- a/x509/json.go
+++ b/x509/json.go
@@ -5,7 +5,6 @@
 package x509
 
 import (
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/asn1"
@@ -13,6 +12,8 @@ import (
 	"errors"
 	"net"
 	"sort"
+
+	"github.com/zmap/zcrypto/dsa"
 
 	"strings"
 	"time"

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -21,7 +21,6 @@ import (
 
 	"bytes"
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -36,6 +35,8 @@ import (
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/zmap/zcrypto/dsa"
 
 	"github.com/weppos/publicsuffix-go/publicsuffix"
 	"github.com/zmap/zcrypto/x509/ct"

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -6,7 +6,6 @@ package x509
 
 import (
 	"bytes"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,6 +25,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/zmap/zcrypto/dsa"
 
 	"github.com/zmap/zcrypto/x509/pkix"
 	"golang.org/x/crypto/curve25519"


### PR DESCRIPTION
The previous change to vendor the `crypto/dsa` package did not update all code points that use that package, which meant that, for example. `zcrypto/x509` would leak `crypto/dsa`. This would, in turn, cause `*dsa.PublicKey is not *dsa.PublicKey` type errors because they are the same name from different scopes.