### PR TITLE
fix cert validity

### DIFF
--- a/x509/json.go
+++ b/x509/json.go
@@ -25,7 +25,7 @@ var kMinTime, kMaxTime time.Time
 
 func init() {
 	var err error
-	kMinTime, err = time.Parse(time.RFC3339, "1970-01-01T00:00:00Z")
+	kMinTime, err = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	if err != nil {
 		panic(err)
 	}
@@ -218,7 +218,7 @@ func (v *validity) MarshalJSON() ([]byte, error) {
 	aux := auxValidity{
 		Start:          clampTime(v.NotBefore.UTC()).Format(time.RFC3339),
 		End:            clampTime(v.NotAfter.UTC()).Format(time.RFC3339),
-		ValidityPeriod: int(v.NotAfter.Sub(v.NotBefore).Seconds()),
+		ValidityPeriod: int(v.NotAfter.Unix() - v.NotBefore.Unix()),
 	}
 	return json.Marshal(&aux)
 }
@@ -235,7 +235,6 @@ func (v *validity) UnmarshalJSON(b []byte) error {
 	if v.NotAfter, err = time.Parse(time.RFC3339, aux.End); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/x509/json_test.go
+++ b/x509/json_test.go
@@ -236,6 +236,10 @@ func TestPublicKeyAlgorithmJSON(t *testing.T) {
 }
 
 func TestValidityJSON(t *testing.T) {
+	preEpoch, err := time.Parse("20060102150405", "19040824000000")
+	if err != nil {
+		t.Error(err)
+	}
 	tests := []validity{
 		{
 			NotBefore: time.Unix(1400000000, 0),
@@ -244,6 +248,18 @@ func TestValidityJSON(t *testing.T) {
 		{
 			NotBefore: time.Unix(1000000000, 0),
 			NotAfter:  time.Unix(1700000000, 0),
+		},
+		{
+			NotBefore: preEpoch,
+			NotAfter:  preEpoch,
+		},
+		{
+			NotBefore: kMinTime,
+			NotAfter:  kMaxTime,
+		},
+		{
+			NotBefore: kMaxTime,
+			NotAfter:  kMinTime,
 		},
 	}
 	for i, v := range tests {


### PR DESCRIPTION
This PR updates the clampTime minimum to be the start of timestamp instead of the epoch.

It also updates the validity length computation to use integer math on the seconds instead of time math. This is because time.Duration() has a limit of around 290 years while the new possible range is nearly 10k years.