### PR TITLE
TLS1.3 Feature Branch: Add back in SessionTicket support

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -512,6 +512,7 @@ func requiresClientCert(c ClientAuthType) bool {
 // sessions.
 type ClientSessionState struct {
 	sessionTicket      []uint8                 // Encrypted ticket used for session resumption with server
+	lifetimeHint       uint32                  // Hint from server about how long the session ticket should be stored
 	vers               uint16                  // TLS version negotiated for the session
 	cipherSuite        uint16                  // Ciphersuite negotiated for the session
 	masterSecret       []byte                  // Full handshake MasterSecret, or TLS 1.3 resumption_master_secret

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -167,6 +167,10 @@ func (c *Conn) clientHandshake() (err error) {
 
 	c.handshakeLog = new(ServerHandshake)
 
+	if c.config.ForceSessionTicketExt {
+		hello.ticketSupported = true
+	}
+
 	if _, err := c.writeRecord(recordTypeHandshake, hello.marshal()); err != nil {
 		return err
 	}

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -817,6 +817,7 @@ func (hs *clientHandshakeState) readSessionTicket() error {
 		cipherSuite:        hs.suite.id,
 		masterSecret:       hs.masterSecret,
 		serverCertificates: c.peerCertificates,
+		lifetimeHint:       sessionTicketMsg.lifetimeHint,
 		verifiedChains:     c.verifiedChains,
 		receivedAt:         c.config.time(),
 		ocspResponse:       c.ocspResponse,

--- a/tls/handshake_messages.go
+++ b/tls/handshake_messages.go
@@ -1753,8 +1753,9 @@ func (m *certificateVerifyMsg) unmarshal(data []byte) bool {
 }
 
 type newSessionTicketMsg struct {
-	raw    []byte
-	ticket []byte
+	raw          []byte
+	ticket       []byte
+	lifetimeHint uint32
 }
 
 func (m *newSessionTicketMsg) marshal() (x []byte) {
@@ -1790,6 +1791,8 @@ func (m *newSessionTicketMsg) unmarshal(data []byte) bool {
 	if uint32(len(data))-4 != length {
 		return false
 	}
+
+	m.lifetimeHint = uint32(data[4])<<24 | uint32(data[5])<<16 | uint32(data[6])<<8 | uint32(data[7])
 
 	ticketLen := int(data[8])<<8 + int(data[9])
 	if len(data)-10 != ticketLen {

--- a/tls/tls_handshake.go
+++ b/tls/tls_handshake.go
@@ -467,7 +467,7 @@ func (m *ClientSessionState) MakeLog() *SessionTicket {
 	st.Length = len(m.sessionTicket)
 	st.Value = make([]uint8, st.Length)
 	copy(st.Value, m.sessionTicket)
-	// st.LifetimeHint = m.lifetimeHint
+	st.LifetimeHint = m.lifetimeHint
 	return st
 }
 


### PR DESCRIPTION
This restores the functionality from master branch commit db98bd3, onto the TLS 1.3 feature branch.

It also adds support for the Config option to force the session ticket client extension.