### PR TITLE
TLS 1.3: don't create skx log if processing server key exchange failed

### DIFF
--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -541,12 +541,11 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 	if ok {
 		hs.finishedHash.Write(skx.marshal())
 		err = keyAgreement.processServerKeyExchange(c.config, hs.hello, hs.serverHello, c.peerCertificates[0], skx)
-
-		c.handshakeLog.ServerKeyExchange = skx.MakeLog(keyAgreement)
 		if err != nil {
 			c.sendAlert(alertUnexpectedMessage)
 			return err
 		}
+		c.handshakeLog.ServerKeyExchange = skx.MakeLog(keyAgreement)
 
 		msg, err = c.readHandshake()
 		if err != nil {


### PR DESCRIPTION
If we attempt to create the skx log when `processServerKeyExchange` fails, then we will likely panic when looking up the elliptic curve.