### PR TITLE
tls 1.3: Add support for SupportedVersions Extension in log

### DIFF
--- a/tls/tls_handshake.go
+++ b/tls/tls_handshake.go
@@ -57,15 +57,20 @@ type ServerHello struct {
 	SessionID   []byte        `json:"session_id"`
 	CipherSuite CipherSuiteID `json:"cipher_suite"`
 	// TODO FIXME: Why is this a raw uint8, not a CompressionMethod?
-	CompressionMethod           uint8             `json:"compression_method"`
-	OcspStapling                bool              `json:"ocsp_stapling"`
-	TicketSupported             bool              `json:"ticket"`
-	SecureRenegotiation         bool              `json:"secure_renegotiation"`
-	HeartbeatSupported          bool              `json:"heartbeat"`
-	ExtendedRandom              []byte            `json:"extended_random,omitempty"`
-	ExtendedMasterSecret        bool              `json:"extended_master_secret"`
-	SignedCertificateTimestamps []ParsedAndRawSCT `json:"scts,omitempty"`
-	AlpnProtocol                string            `json:"alpn_protocol,omitempty"`
+	CompressionMethod           uint8                 `json:"compression_method"`
+	OcspStapling                bool                  `json:"ocsp_stapling"`
+	TicketSupported             bool                  `json:"ticket"`
+	SecureRenegotiation         bool                  `json:"secure_renegotiation"`
+	HeartbeatSupported          bool                  `json:"heartbeat"`
+	ExtendedRandom              []byte                `json:"extended_random,omitempty"`
+	ExtendedMasterSecret        bool                  `json:"extended_master_secret"`
+	SignedCertificateTimestamps []ParsedAndRawSCT     `json:"scts,omitempty"`
+	AlpnProtocol                string                `json:"alpn_protocol,omitempty"`
+	SupportedVersions           *SupportedVersionsExt `json:"supported_versions,omitempty"`
+}
+
+type SupportedVersionsExt struct {
+	SelectedVersion TLSVersion `json:"selected_version"`
 }
 
 // SimpleCertificate holds a *x509.Certificate and a []byte for the certificate
@@ -354,6 +359,13 @@ func (m *serverHelloMsg) MakeLog() *ServerHello {
 	}
 	//sh.ExtendedMasterSecret = m.extendedMasterSecret
 	sh.AlpnProtocol = m.alpnProtocol
+
+	// TLS 1.3 SupportedVersions
+	if m.supportedVersion != 0 {
+		sh.SupportedVersions = &SupportedVersionsExt{
+			SelectedVersion: TLSVersion(m.supportedVersion),
+		}
+	}
 	return sh
 }
 

--- a/tls/tls_names.go
+++ b/tls/tls_names.go
@@ -579,6 +579,8 @@ func (v TLSVersion) String() string {
 		return "TLSv1.1"
 	case 0x0303:
 		return "TLSv1.2"
+	case 0x0304:
+		return "TLSv1.3"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
For TLS 1.3 connections, SupportedVersions.SelectedVersions will be
present, and be 0x0304.  Add this to the HandshakeLog, if present.