### PR TITLE
handshake_client: do not overwrite server certs

### DIFF
--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -589,8 +589,6 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		if _, err := c.writeRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
 			return err
 		}
-
-		c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 	}
 
 	preMasterSecret, ckx, err := keyAgreement.generateClientKeyExchange(c.config, hs.hello, c.peerCertificates[0])


### PR DESCRIPTION
Do not overwrite collected server certs when we are asked for a client cert.

Test against any TLS config that requires a client certificate.

Before this patch, we should not have cert info in the handshake log; afterwards, the server certs should be collected regardless of the handshake's success.