### PR TITLE
Added extension identifiers for Server Hello messages to Handshake Log

### DIFF
--- a/tls/handshake_messages.go
+++ b/tls/handshake_messages.go
@@ -610,6 +610,7 @@ type serverHelloMsg struct {
 	selectedIdentityPresent      bool
 	selectedIdentity             uint16
 	supportedPoints              []uint8
+	extensionIdentifiers         []uint16
 
 	// HelloRetryRequest extensions
 	cookie        []byte
@@ -761,6 +762,8 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 			!extensions.ReadUint16LengthPrefixed(&extData) {
 			return false
 		}
+
+		m.extensionIdentifiers = append(m.extensionIdentifiers, extension)
 
 		switch extension {
 		case extensionStatusRequest:

--- a/tls/handshake_messages.go
+++ b/tls/handshake_messages.go
@@ -833,6 +833,7 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 			// Ignore unknown extensions.
 			continue
 		}
+
 		if !extData.Empty() {
 			return false
 		}

--- a/tls/tls_handshake.go
+++ b/tls/tls_handshake.go
@@ -67,6 +67,7 @@ type ServerHello struct {
 	SignedCertificateTimestamps []ParsedAndRawSCT     `json:"scts,omitempty"`
 	AlpnProtocol                string                `json:"alpn_protocol,omitempty"`
 	SupportedVersions           *SupportedVersionsExt `json:"supported_versions,omitempty"`
+	ExtensionIdentifiers        []uint16              `json:"extension_identifiers,omitempty"`
 }
 
 type SupportedVersionsExt struct {
@@ -344,6 +345,7 @@ func (m *serverHelloMsg) MakeLog() *ServerHello {
 	sh.OcspStapling = m.ocspStapling
 	sh.TicketSupported = m.ticketSupported
 	sh.SecureRenegotiation = m.secureRenegotiationSupported && len(m.secureRenegotiation) > 0
+	sh.ExtensionIdentifiers = m.extensionIdentifiers
 
 	if len(m.scts) > 0 {
 		for _, rawSCT := range m.scts {

--- a/tls/tls_handshake.go
+++ b/tls/tls_handshake.go
@@ -345,7 +345,10 @@ func (m *serverHelloMsg) MakeLog() *ServerHello {
 	sh.OcspStapling = m.ocspStapling
 	sh.TicketSupported = m.ticketSupported
 	sh.SecureRenegotiation = m.secureRenegotiationSupported && len(m.secureRenegotiation) > 0
-	sh.ExtensionIdentifiers = m.extensionIdentifiers
+	extensionIdentifiers, success := m.extractExtensions()
+	if success {
+		sh.ExtensionIdentifiers = extensionIdentifiers
+	}
 
 	if len(m.scts) > 0 {
 		for _, rawSCT := range m.scts {


### PR DESCRIPTION
In order to enable generating JA3S fingerprints for a TLS connection, we would like to include *all* extension identifiers as integers and include this information in TLS handshake logs.