### PR TITLE
Fix x509 system certificate pool for js/wasm

### DIFF
--- a/ct/x509/root_js.go
+++ b/ct/x509/root_js.go
@@ -1,0 +1,18 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build js,wasm
+
+package x509
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{}
+
+func loadSystemRoots() (*CertPool, error) {
+	return NewCertPool(), nil
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}


### PR DESCRIPTION
This commit introduces the changes that were committed with
the PR at https://github.com/google/certificate-transparency-go/pull/609
to zcrypto. This makes `GOOS=js GOARCH=wasm go build ./...` work.