### PR TITLE
Add option for CT log client to emit unparseable certs

### DIFF
--- a/ct/types.go
+++ b/ct/types.go
@@ -236,12 +236,16 @@ func (d *DigitallySigned) UnmarshalJSON(b []byte) error {
 
 // LogEntry represents the contents of an entry in a CT log, see section 3.1.
 type LogEntry struct {
-	Index    int64
-	Leaf     MerkleTreeLeaf
+	Index     int64
+	Leaf      MerkleTreeLeaf
+	RawCert   []byte
+	IsPrecert bool
+	Chain     []ASN1Cert
+	Server    string
+	// When the raw cert is parseable, and not a precert,
+	// X509Cert contains the parsed certificate for convenience.
 	X509Cert *x509.Certificate
 	Precert  *Precertificate
-	Chain    []ASN1Cert
-	Server   string
 }
 
 // SHA256Hash represents the output from the SHA256 hash function.
@@ -347,8 +351,8 @@ type Precertificate struct {
 	// SHA256 hash of the issuing key
 	IssuerKeyHash [issuerKeyHashLength]byte
 	// Parsed TBSCertificate structure (held in an x509.Certificate for ease of
-	// access.
-	TBSCertificate x509.Certificate
+	// access), when possible.
+	TBSCertificate *x509.Certificate
 }
 
 // X509Certificate returns the X.509 Certificate contained within the

--- a/ct/x509/sec1.go
+++ b/ct/x509/sec1.go
@@ -7,6 +7,7 @@ package x509
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+
 	// START CT CHANGES
 	"github.com/zmap/zcrypto/ct/asn1"
 	// START CT CHANGES

--- a/x509/pkcs8.go
+++ b/x509/pkcs8.go
@@ -98,9 +98,9 @@ func MarshalPKCS8PrivateKey(key interface{}) ([]byte, error) {
 		privKey.PrivateKey = MarshalPKCS1PrivateKey(k)
 
 	case *ecdsa.PrivateKey:
-		oid, ok := oidFromNamedCurve(k.Curve)
-		if !ok {
-			return nil, errors.New("x509: unknown curve while marshaling to PKCS#8")
+		oid, err := oidFromNamedCurve(k.Curve)
+		if err != nil {
+			return nil, err
 		}
 
 		oidBytes, err := asn1.Marshal(oid)

--- a/x509/sec1.go
+++ b/x509/sec1.go
@@ -36,9 +36,9 @@ func ParseECPrivateKey(der []byte) (*ecdsa.PrivateKey, error) {
 
 // MarshalECPrivateKey marshals an EC private key into ASN.1, DER format.
 func MarshalECPrivateKey(key *ecdsa.PrivateKey) ([]byte, error) {
-	oid, ok := oidFromNamedCurve(key.Curve)
-	if !ok {
-		return nil, errors.New("x509: unknown elliptic curve")
+	oid, err := oidFromNamedCurve(key.Curve)
+	if err != nil {
+		return nil, err
 	}
 
 	privateKeyBytes := key.D.Bytes()
@@ -80,12 +80,12 @@ func parseECPrivateKey(namedCurveOID *asn1.ObjectIdentifier, der []byte) (key *e
 
 	var curve elliptic.Curve
 	if namedCurveOID != nil {
-		curve = namedCurveFromOID(*namedCurveOID)
+		curve, err = namedCurveFromOID(*namedCurveOID)
 	} else {
-		curve = namedCurveFromOID(privKey.NamedCurveOID)
+		curve, err = namedCurveFromOID(privKey.NamedCurveOID)
 	}
-	if curve == nil {
-		return nil, errors.New("x509: unknown elliptic curve")
+	if err != nil {
+		return nil, err
 	}
 
 	k := new(big.Int).SetBytes(privKey.PrivateKey)


### PR DESCRIPTION

- Allow CT log client to provide `IgnoreParsingErrors`, causing certs to be emitted regardless of parse status
- Standardize & export parsing error caused by unsupported elliptic curve