### PR TITLE
tls: perform type assertion on cert publickey

### DIFF
--- a/tls/key_agreement.go
+++ b/tls/key_agreement.go
@@ -250,7 +250,11 @@ func (ka rsaKeyAgreement) generateClientKeyExchange(config *Config, clientHello 
 		return nil, nil, err
 	}
 
-	encrypted, err := rsa.EncryptPKCS1v15(config.rand(), cert.PublicKey.(*rsa.PublicKey), preMasterSecret)
+	publicKey, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, nil, errClientKeyExchange
+	}
+	encrypted, err := rsa.EncryptPKCS1v15(config.rand(), publicKey, preMasterSecret)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Prior to the TLS 1.3 backport, there was a type assertion to make sure that `cert.PublicKey.(*rsa.PublicKey)` was true.  This was lost in the backport work, and while very rare we did recently hit a case where this assertion is not true.  Doing it inline in the call leads to a panic.

This restores the prior type assertion check, and returns err if it fails.
