### PR TITLE
Adding CertsOnly field in Config.Clone method

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -578,6 +578,7 @@ func (c *Config) Clone() *Config {
 		ExplicitCurvePreferences:       c.ExplicitCurvePreferences,
 		sessionTicketKeys:              sessionTicketKeys,
 		ClientFingerprintConfiguration: c.ClientFingerprintConfiguration,
+		CertsOnly:                      c.CertsOnly,
 		// originalConfig is deliberately not duplicated.
 
 		// Not merged from upstream:


### PR DESCRIPTION
## Description
This PR adds the `CertsOnly` field to the cloned struct in the `Config.Clone()` method in `tls/common.go`. This fixes cases where multiple copies with customized settings of `tls.Config` are used.