### PR TITLE
Expose 'validSignature' field

### DIFF
--- a/x509/cert_pool.go
+++ b/x509/cert_pool.go
@@ -49,7 +49,7 @@ func (s *CertPool) findVerifiedParents(cert *Certificate) (parents []int, errCer
 
 	for _, c := range candidates {
 		if err = cert.CheckSignatureFrom(s.certs[c]); err == nil {
-			cert.validSignature = true
+			cert.ValidSignature = true
 			parents = append(parents, c)
 		} else {
 			errCert = s.certs[c]

--- a/x509/json.go
+++ b/x509/json.go
@@ -488,7 +488,7 @@ func (c *Certificate) MarshalJSON() ([]byte, error) {
 	jc.SignatureAlgorithm = c.jsonifySignatureAlgorithm()
 	jc.Signature.SignatureAlgorithm = jc.SignatureAlgorithm
 	jc.Signature.Value = c.Signature
-	jc.Signature.Valid = c.validSignature
+	jc.Signature.Valid = c.ValidSignature
 	jc.Signature.SelfSigned = c.SelfSigned
 	if c.SelfSigned {
 		jc.Signature.Valid = true

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -865,8 +865,9 @@ type Certificate struct {
 
 	IsPrecert bool
 
-	// Internal
-	validSignature bool
+	// ValidSignature is true if the certificate was signed by any roots or
+	// intermediates given in a call to (*Certificate).Verify().
+	ValidSignature bool
 
 	// CT
 	SignedCertificateTimestampList []*ct.SignedCertificateTimestamp


### PR DESCRIPTION
Exposes `(*x509.Certificate).validSignature` so that it can be read without marshalling the entire certificate to JSON.