### PR TITLE
Bring in support for Certificate Revocation Lists

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2268,7 +2268,7 @@ func buildExtensions(template *Certificate, _ []byte) (ret []pkix.Extension, err
 		a[0] = reverseBitsInAByte(byte(template.KeyUsage))
 		a[1] = reverseBitsInAByte(byte(template.KeyUsage >> 8))
 
-		l := 1
+		l := 1z
 		if a[1] != 0 {
 			l = 2
 		}
@@ -3091,4 +3091,58 @@ func parseCertificateRequest(in *certificateRequest) (*CertificateRequest, error
 // CheckSignature reports whether the signature on c is valid.
 func (c *CertificateRequest) CheckSignature() error {
 	return CheckSignatureFromKey(c.PublicKey, c.SignatureAlgorithm, c.RawTBSCertificateRequest, c.Signature)
+}
+
+// RevocationList contains the fields used to create an X.509 v2 Certificate
+// Revocation list with CreateRevocationList.
+type RevocationList struct {
+	// Raw contains the complete ASN.1 DER content of the CRL (tbsCertList,
+	// signatureAlgorithm, and signatureValue.)
+	Raw []byte
+	// RawTBSRevocationList contains just the tbsCertList portion of the ASN.1
+	// DER.
+	RawTBSRevocationList []byte
+	// RawIssuer contains the DER encoded Issuer.
+	RawIssuer []byte
+
+	// Issuer contains the DN of the issuing certificate.
+	Issuer pkix.Name
+	// AuthorityKeyId is used to identify the public key associated with the
+	// issuing certificate. It is populated from the authorityKeyIdentifier
+	// extension when parsing a CRL. It is ignored when creating a CRL; the
+	// extension is populated from the issuing certificate itself.
+	AuthorityKeyId []byte
+
+	Signature []byte
+	// SignatureAlgorithm is used to determine the signature algorithm to be
+	// used when signing the CRL. If 0 the default algorithm for the signing
+	// key will be used.
+	SignatureAlgorithm SignatureAlgorithm
+
+	// RevokedCertificates is used to populate the revokedCertificates
+	// sequence in the CRL, it may be empty. RevokedCertificates may be nil,
+	// in which case an empty CRL will be created.
+	RevokedCertificates []pkix.RevokedCertificate
+
+	// Number is used to populate the X.509 v2 cRLNumber extension in the CRL,
+	// which should be a monotonically increasing sequence number for a given
+	// CRL scope and CRL issuer. It is also populated from the cRLNumber
+	// extension when parsing a CRL.
+	Number *big.Int
+
+	// ThisUpdate is used to populate the thisUpdate field in the CRL, which
+	// indicates the issuance date of the CRL.
+	ThisUpdate time.Time
+	// NextUpdate is used to populate the nextUpdate field in the CRL, which
+	// indicates the date by which the next CRL will be issued. NextUpdate
+	// must be greater than ThisUpdate.
+	NextUpdate time.Time
+
+	// Extensions contains raw X.509 extensions. When creating a CRL,
+	// the Extensions field is ignored, see ExtraExtensions.
+	Extensions []pkix.Extension
+
+	// ExtraExtensions contains any additional extensions to add directly to
+	// the CRL.
+	ExtraExtensions []pkix.Extension
 }

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -26,7 +26,6 @@ import (
 	"crypto/rsa"
 	_ "crypto/sha1"
 	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -2268,7 +2267,7 @@ func buildExtensions(template *Certificate, _ []byte) (ret []pkix.Extension, err
 		a[0] = reverseBitsInAByte(byte(template.KeyUsage))
 		a[1] = reverseBitsInAByte(byte(template.KeyUsage >> 8))
 
-		l := 1z
+		l := 1
 		if a[1] != 0 {
 			l = 2
 		}


### PR DESCRIPTION
This change brings in the RevocationList type from https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/crypto/x509/x509.go;l=2154

It's ultimate purpose is to bring in the capability in order to enable ZLint to perform lints on CRLs (for more information, please see https://github.com/zmap/zlint/pull/699)