### PR TITLE
verifier: set ValidSignature field

### DIFF
--- a/verifier/walk.go
+++ b/verifier/walk.go
@@ -46,6 +46,7 @@ func (g *Graph) WalkChainsAsync(c *x509.Certificate, opt WalkOptions) chan x509.
 				continue
 			}
 			start.issuer = candidate
+			c.ValidSignature = true
 			break
 		}
 	}


### PR DESCRIPTION
The x509 package sets this field true when it finds a valid signature while validating certificates; copy the behavior here for consistency.