### PR TITLE
verifier: set ValidSignature for certificates in the graph

### DIFF
--- a/verifier/walk.go
+++ b/verifier/walk.go
@@ -49,7 +49,11 @@ func (g *Graph) WalkChainsAsync(c *x509.Certificate, opt WalkOptions) chan x509.
 			c.ValidSignature = true
 			break
 		}
+	} else {
+		// We already trust the signatures in the graph.
+		c.ValidSignature = true
 	}
+
 	go g.walkFromEdgeToRoot(start, out)
 	return out
 }


### PR DESCRIPTION
Certificates which are used to make trust decisions (present in the validation graph) did not correctly have the `ValidSignature` field set when they were verified.

The signatures of certificates in the graph _are_ valid, so change this.