### PR TITLE
tls: fix dropped error

### DIFF
--- a/tls/key_agreement.go
+++ b/tls/key_agreement.go
@@ -384,6 +384,9 @@ func (ka *signedKeyAgreement) signParameters(config *Config, cert *Certificate, 
 			return nil, errors.New("failed to sign ECDHE parameters: " + err.Error())
 		}
 		sig, err = asn1.Marshal(ecdsaSignature{r, s})
+		if err != nil {
+			return nil, errors.New("failed to marshal ECDSA signature: " + err.Error())
+		}
 	case signatureRSA:
 		privKey, ok := cert.PrivateKey.(*rsa.PrivateKey)
 		if !ok {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `tls` package.