### PR TITLE
ct/x509: fix dropped error

### DIFF
--- a/ct/x509/x509.go
+++ b/ct/x509/x509.go
@@ -66,6 +66,9 @@ func marshalPublicKey(pub interface{}) (publicKeyBytes []byte, publicKeyAlgorith
 			N: pub.N,
 			E: pub.E,
 		})
+		if err != nil {
+			return
+		}
 		publicKeyAlgorithm.Algorithm = oidPublicKeyRSA
 		// This is a NULL parameters value which is technically
 		// superfluous, but most other code includes it and, by


### PR DESCRIPTION
This fixes a dropped `err` variable in `ct/x509`.