### PR TITLE
ct/asn1: fix dropped error

### DIFF
--- a/ct/asn1/marshal.go
+++ b/ct/asn1/marshal.go
@@ -564,6 +564,9 @@ func marshalField(out *forkableWriter, v reflect.Value, params fieldParameters) 
 			length:     bodyLen + tags.Len(),
 			isCompound: true,
 		})
+		if err != nil {
+			return
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This fixes a dropped `err` variable in `ct/asn1`.