### PR TITLE
Make ocsp stapling and supported EC points configurable

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -438,6 +438,17 @@ type Config struct {
 	// supported for ECDHE key exchanges
 	ExplicitCurvePreferences bool
 
+	// EC Point Formats. Specifies what compressed points the client supports
+	SupportedPoints []uint8
+
+	// Online Certificate Status Protocol (OCSP) stapling,
+	// formally knows as TLS Certificate Status Request.
+	// If this option enabled, the certificate status won't be checked
+	NoOcspStapling bool
+
+	// Specifies what compression methods the client supports
+	CompressionMethods []uint8
+
 	// If enabled, specifies the signature and hash algorithms to be accepted by
 	// a server, or sent by a client
 	SignatureAndHashes []SigAndHash

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -319,14 +319,28 @@ func (c *Conn) clientHandshake() error {
 			return errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
 		}
 
+		supportedPoints := []uint8{pointFormatUncompressed}
+		if c.config.SupportedPoints != nil {
+			supportedPoints = c.config.SupportedPoints
+		}
+		oscpStapling := true
+		if c.config.NoOcspStapling {
+			oscpStapling = false
+		}
+
+		compressionMethods := []uint8{compressionNone}
+		if c.config.CompressionMethods != nil {
+			compressionMethods = c.config.CompressionMethods
+		}
+
 		hello = &clientHelloMsg{
 			vers:                 c.config.maxVersion(),
-			compressionMethods:   []uint8{compressionNone},
+			compressionMethods:   compressionMethods,
 			random:               make([]byte, 32),
-			ocspStapling:         true,
+			ocspStapling:         oscpStapling,
 			serverName:           c.config.ServerName,
 			supportedCurves:      c.config.curvePreferences(),
-			supportedPoints:      []uint8{pointFormatUncompressed},
+			supportedPoints:      supportedPoints,
 			nextProtoNeg:         len(c.config.NextProtos) > 0,
 			secureRenegotiation:  true,
 			alpnProtocols:        c.config.NextProtos,


### PR DESCRIPTION
I left the default behavior of ClientHello the same but made some fields configurable through Config.