### PR TITLE
Fix keyUsage encoding to be a valid DER encoded BitString.

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2274,7 +2274,7 @@ func buildExtensions(template *Certificate, _ []byte) (ret []pkix.Extension, err
 			l = 2
 		}
 
-		ret[n].Value, err = asn1.Marshal(asn1.BitString{Bytes: a[0:l], BitLength: l * 8})
+		ret[n].Value, err = asn1.Marshal(asn1.BitString{Bytes: a[0:l], BitLength: asn1BitLength(a[0:l])})
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Certificates created using the zcrypto x509 library do not pass the [e_incorrect_ku_encoding zlint check](https://github.com/zmap/zlint/blob/1c307f4b9ef04348f621ce0a03e2bf0d5e471fbc/v3/lints/rfc/lint_incorrect_ku_encoding.go): RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself defines that all trailing 0 bits be counted as being "unused".

[Here is how the Go stdlib does it](https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/crypto/x509/x509.go;drc=82c713feb05da594567631972082af2fcba0ee4f;l=1331).