### PR TITLE
make extension parsing more permissive

### DIFF
--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/zmap/zcrypto/encoding/asn1"
 	"github.com/zmap/zcrypto/x509"
 )
 
@@ -853,7 +854,7 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 	certs := make([]*x509.Certificate, len(certificates))
 	for i, asn1Data := range certificates {
 		cert, err := x509.ParseCertificate(asn1Data)
-		if err != nil {
+		if err != nil && (!asn1.AllowPermissiveParsing || !strings.HasPrefix(err.Error(), "permissive")) {
 			c.sendAlert(alertBadCertificate)
 			return errors.New("tls: failed to parse certificate from server: " + err.Error())
 		}


### PR DESCRIPTION
if allowpermissive, then tolerate errors in extension parsing

searched for returns in parsecertificate. continued in each case for an easy check that this is as nil safe as the code was before

here is a cert that we can now permissively parse:

`MIICQDCCAamgAwIBAgIQa9ciWy1lvZtGRujXx93btjANBgkqhkiG9w0BAQUFADBAMRowGAYDVQQDExFEaWdpQ2VydCBzZWN1cml0eTEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMQswCQYDVQQGEwJVUzAeFw0yMzA3MDQyMTE3MjRaFw0yNTA3MDQyMTE3MjRaMEAxGjAYBgNVBAMTEURpZ2lDZXJ0IHNlY3VyaXR5MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxCzAJBgNVBAYTAlVTMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCoqY2vi90BoFCGapgvjh2uCtqKBOFjN+3kU2Lc2UuSlt/pbJIBsRK+pAFkgy1khodbkzthiuzzDzqb95Y9a3eJ+G3dx1aW872v8ub8qe/ZlXOVDnNh/AahIzKlBGE3cuCT7eHJnGHt2tUmAoCc5OodgXdso6vKYxdYrszLrDnYWQIDAQABozswOTALBgNVHQ4EBAMCA7gwCwYDVR0PBAQDAgO4MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQUFAAOBgQCnChlYocxRYGl7QSq5luUpak2L5u0PcsEzCUd9yIUCB1eubqMVQTJfp7frMWM313aBpNeWQ3leLZvNn3hzPPBWy8ZH18plZRjkTxh9U7cEK3I/yltzLlZdUPNqgEJdeHMHYjKtO7LcZATm+DAhkk0HdX0KS4dN0G+zFKFWCEPhCg==`