### PR TITLE
fix(extensions): include critical field for NameConstraints JSON

### DIFF
--- a/x509/extensions.go
+++ b/x509/extensions.go
@@ -253,6 +253,7 @@ func (nc *NameConstraints) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
+	nc.Critical = ncJson.Critical
 	for _, dns := range ncJson.PermittedDNSNames {
 		nc.PermittedDNSNames = append(nc.PermittedDNSNames, GeneralSubtreeString{Data: dns})
 	}
@@ -321,6 +322,7 @@ func (nc *NameConstraints) UnmarshalJSON(b []byte) error {
 
 func (nc NameConstraints) MarshalJSON() ([]byte, error) {
 	var out NameConstraintsJSON
+	out.Critical = nc.Critical
 	for _, dns := range nc.PermittedDNSNames {
 		out.PermittedDNSNames = append(out.PermittedDNSNames, dns.Data)
 	}
@@ -772,7 +774,6 @@ func (c *Certificate) JsonifyExtensions() (*CertificateExtensions, UnknownCertif
 			exts.NameConstraints.PermittedDirectoryNames = c.PermittedDirectoryNames
 			exts.NameConstraints.PermittedEdiPartyNames = c.PermittedEdiPartyNames
 			exts.NameConstraints.PermittedRegisteredIDs = c.PermittedRegisteredIDs
-
 			exts.NameConstraints.ExcludedEmailAddresses = c.ExcludedEmailAddresses
 			exts.NameConstraints.ExcludedDNSNames = c.ExcludedDNSNames
 			exts.NameConstraints.ExcludedURIs = c.ExcludedURIs

--- a/x509/extensions_test.go
+++ b/x509/extensions_test.go
@@ -212,6 +212,11 @@ func TestNameConstraintJSON(t *testing.T) {
 		},
 		{
 			nc: NameConstraints{
+				Critical: true,
+			},
+		},
+		{
+			nc: NameConstraints{
 				PermittedDNSNames: []GeneralSubtreeString{
 					{
 						Data: "censys.io",
@@ -335,6 +340,9 @@ func TestNameConstraintJSON(t *testing.T) {
 			continue
 		}
 
+		if test.nc.Critical != backToNC.Critical {
+			t.Errorf("%d: JSON Unmarshal did not preserve all values", i)
+		}
 		for _, e := range backToNC.PermittedDNSNames {
 			if !containsGeneralSubtreeString(test.nc.PermittedDNSNames, e) {
 				t.Errorf("%d: JSON Unmarshal did not preserve all values", i)


### PR DESCRIPTION
The `Critical` field for `NameConstraints` is correctly parsed, but ignored when marshalling/unmarshalling certificates to JSON. Fix this, and add a test for it.