### PR TITLE
Expose write record from Conn

### DIFF
--- a/tls/conn.go
+++ b/tls/conn.go
@@ -1006,9 +1006,9 @@ func (c *Conn) writeRecordLocked(typ recordType, data []byte) (int, error) {
 	return n, nil
 }
 
-// writeRecord writes a TLS record with the given type and payload to the
+// WriteRecord writes a TLS record with the given type and payload to the
 // connection and updates the record layer state.
-func (c *Conn) writeRecord(typ recordType, data []byte) (int, error) {
+func (c *Conn) WriteRecord(typ recordType, data []byte) (int, error) {
 	c.out.Lock()
 	defer c.out.Unlock()
 

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -454,7 +454,7 @@ func (c *Conn) clientHandshake() (err error) {
 		hello.sctEnabled = true
 	}
 
-	if _, err := c.writeRecord(recordTypeHandshake, hello.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, hello.marshal()); err != nil {
 		return err
 	}
 
@@ -869,7 +869,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		certMsg = new(certificateMsg)
 		certMsg.certificates = chainToSend.Certificate
 		hs.finishedHash.Write(certMsg.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
 			return err
 		}
 	}
@@ -885,7 +885,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 
 	if ckx != nil {
 		hs.finishedHash.Write(ckx.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, ckx.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, ckx.marshal()); err != nil {
 			return err
 		}
 	}
@@ -933,7 +933,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		}
 
 		hs.finishedHash.Write(certVerify.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, certVerify.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, certVerify.marshal()); err != nil {
 			return err
 		}
 	}
@@ -1115,7 +1115,7 @@ func (hs *clientHandshakeState) readSessionTicket() error {
 func (hs *clientHandshakeState) sendFinished(out []byte) error {
 	c := hs.c
 
-	if _, err := c.writeRecord(recordTypeChangeCipherSpec, []byte{1}); err != nil {
+	if _, err := c.WriteRecord(recordTypeChangeCipherSpec, []byte{1}); err != nil {
 		return err
 	}
 
@@ -1124,7 +1124,7 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
 	hs.finishedHash.Write(finished.marshal())
 	c.handshakeLog.ClientFinished = finished.MakeLog()
 
-	if _, err := c.writeRecord(recordTypeHandshake, finished.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, finished.marshal()); err != nil {
 		return err
 	}
 	copy(out, finished.verifyData)

--- a/tls/handshake_client_tls13.go
+++ b/tls/handshake_client_tls13.go
@@ -169,7 +169,7 @@ func (hs *clientHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
 	}
 	hs.sentDummyCCS = true
 
-	_, err := hs.c.writeRecord(recordTypeChangeCipherSpec, []byte{1})
+	_, err := hs.c.WriteRecord(recordTypeChangeCipherSpec, []byte{1})
 	return err
 }
 
@@ -262,7 +262,7 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 	}
 
 	hs.transcript.Write(hs.hello.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
 		return err
 	}
 
@@ -571,7 +571,7 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 	certMsg.ocspStapling = hs.certReq.ocspStapling && len(cert.OCSPStaple) > 0
 
 	hs.transcript.Write(certMsg.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
 		return err
 	}
 
@@ -609,7 +609,7 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 	certVerifyMsg.signature = sig
 
 	hs.transcript.Write(certVerifyMsg.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, certVerifyMsg.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, certVerifyMsg.marshal()); err != nil {
 		return err
 	}
 
@@ -624,7 +624,7 @@ func (hs *clientHandshakeStateTLS13) sendClientFinished() error {
 	}
 
 	hs.transcript.Write(finished.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, finished.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, finished.marshal()); err != nil {
 		return err
 	}
 

--- a/tls/handshake_server.go
+++ b/tls/handshake_server.go
@@ -450,7 +450,7 @@ func (hs *serverHandshakeState) doResumeHandshake() error {
 	hs.finishedHash.discardHandshakeBuffer()
 	hs.finishedHash.Write(hs.clientHello.marshal())
 	hs.finishedHash.Write(hs.hello.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
 		return err
 	}
 	c.handshakeLog.ServerHello = hs.hello.MakeLog()
@@ -491,7 +491,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 	}
 	hs.finishedHash.Write(hs.clientHello.marshal())
 	hs.finishedHash.Write(hs.hello.marshal())
-	_, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal())
+	_, err := c.WriteRecord(recordTypeHandshake, hs.hello.marshal())
 	c.handshakeLog.ServerHello = hs.hello.MakeLog()
 	if err != nil {
 		return err
@@ -500,7 +500,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 	certMsg := new(certificateMsg)
 	certMsg.certificates = hs.cert.Certificate
 	hs.finishedHash.Write(certMsg.marshal())
-	_, err = c.writeRecord(recordTypeHandshake, certMsg.marshal())
+	_, err = c.WriteRecord(recordTypeHandshake, certMsg.marshal())
 	c.handshakeLog.ServerCertificates = certMsg.MakeLog()
 	if err != nil {
 		return err
@@ -510,7 +510,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		certStatus := new(certificateStatusMsg)
 		certStatus.response = hs.cert.OCSPStaple
 		hs.finishedHash.Write(certStatus.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, certStatus.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, certStatus.marshal()); err != nil {
 			return err
 		}
 	}
@@ -523,7 +523,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 	}
 	if skx != nil {
 		hs.finishedHash.Write(skx.marshal())
-		_, err := c.writeRecord(recordTypeHandshake, skx.marshal())
+		_, err := c.WriteRecord(recordTypeHandshake, skx.marshal())
 
 		c.handshakeLog.ServerKeyExchange = skx.MakeLog(keyAgreement)
 		if err != nil {
@@ -553,14 +553,14 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 			certReq.certificateAuthorities = c.config.ClientCAs.Subjects()
 		}
 		hs.finishedHash.Write(certReq.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, certReq.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, certReq.marshal()); err != nil {
 			return err
 		}
 	}
 
 	helloDone := new(serverHelloDoneMsg)
 	hs.finishedHash.Write(helloDone.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, helloDone.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, helloDone.marshal()); err != nil {
 		return err
 	}
 
@@ -768,7 +768,7 @@ func (hs *serverHandshakeState) sendSessionTicket() error {
 	}
 
 	hs.finishedHash.Write(m.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, m.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, m.marshal()); err != nil {
 		return err
 	}
 
@@ -778,14 +778,14 @@ func (hs *serverHandshakeState) sendSessionTicket() error {
 func (hs *serverHandshakeState) sendFinished(out []byte) error {
 	c := hs.c
 
-	if _, err := c.writeRecord(recordTypeChangeCipherSpec, []byte{1}); err != nil {
+	if _, err := c.WriteRecord(recordTypeChangeCipherSpec, []byte{1}); err != nil {
 		return err
 	}
 
 	finished := new(finishedMsg)
 	finished.verifyData = hs.finishedHash.serverSum(hs.masterSecret)
 	hs.finishedHash.Write(finished.marshal())
-	_, err := c.writeRecord(recordTypeHandshake, finished.marshal())
+	_, err := c.WriteRecord(recordTypeHandshake, finished.marshal())
 	c.handshakeLog.ServerFinished = finished.MakeLog()
 
 	if err != nil {

--- a/tls/handshake_server_test.go
+++ b/tls/handshake_server_test.go
@@ -35,7 +35,7 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
 		if ch, ok := m.(*clientHelloMsg); ok {
 			cli.vers = ch.vers
 		}
-		cli.writeRecord(recordTypeHandshake, m.marshal())
+		cli.WriteRecord(recordTypeHandshake, m.marshal())
 		c.Close()
 	}()
 	conn := Server(s, serverConfig)
@@ -190,7 +190,7 @@ func TestRenegotiationExtension(t *testing.T) {
 	go func() {
 		cli := Client(c, testConfig)
 		cli.vers = clientHello.vers
-		cli.writeRecord(recordTypeHandshake, clientHello.marshal())
+		cli.WriteRecord(recordTypeHandshake, clientHello.marshal())
 
 		buf := make([]byte, 1024)
 		n, err := c.Read(buf)
@@ -249,7 +249,7 @@ func TestTLS12OnlyCipherSuites(t *testing.T) {
 	go func() {
 		cli := Client(c, testConfig)
 		cli.vers = clientHello.vers
-		cli.writeRecord(recordTypeHandshake, clientHello.marshal())
+		cli.WriteRecord(recordTypeHandshake, clientHello.marshal())
 		reply, err := cli.readHandshake()
 		c.Close()
 		if err != nil {
@@ -304,7 +304,7 @@ func TestTLSPointFormats(t *testing.T) {
 			go func() {
 				cli := Client(c, testConfig)
 				cli.vers = clientHello.vers
-				cli.writeRecord(recordTypeHandshake, clientHello.marshal())
+				cli.WriteRecord(recordTypeHandshake, clientHello.marshal())
 				reply, err := cli.readHandshake()
 				c.Close()
 				if err != nil {
@@ -1419,7 +1419,7 @@ func TestSNIGivenOnFailure(t *testing.T) {
 	go func() {
 		cli := Client(c, testConfig)
 		cli.vers = clientHello.vers
-		cli.writeRecord(recordTypeHandshake, clientHello.marshal())
+		cli.WriteRecord(recordTypeHandshake, clientHello.marshal())
 		c.Close()
 	}()
 	conn := Server(s, serverConfig)

--- a/tls/handshake_server_tls13.go
+++ b/tls/handshake_server_tls13.go
@@ -403,7 +403,7 @@ func (hs *serverHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
 	}
 	hs.sentDummyCCS = true
 
-	_, err := hs.c.writeRecord(recordTypeChangeCipherSpec, []byte{1})
+	_, err := hs.c.WriteRecord(recordTypeChangeCipherSpec, []byte{1})
 	return err
 }
 
@@ -429,7 +429,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 	}
 
 	hs.transcript.Write(helloRetryRequest.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, helloRetryRequest.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, helloRetryRequest.marshal()); err != nil {
 		return err
 	}
 
@@ -530,7 +530,7 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 
 	hs.transcript.Write(hs.clientHello.marshal())
 	hs.transcript.Write(hs.hello.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
 		return err
 	}
 
@@ -573,7 +573,7 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 	}
 
 	hs.transcript.Write(encryptedExtensions.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, encryptedExtensions.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, encryptedExtensions.marshal()); err != nil {
 		return err
 	}
 
@@ -603,7 +603,7 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 		}
 
 		hs.transcript.Write(certReq.marshal())
-		if _, err := c.writeRecord(recordTypeHandshake, certReq.marshal()); err != nil {
+		if _, err := c.WriteRecord(recordTypeHandshake, certReq.marshal()); err != nil {
 			return err
 		}
 	}
@@ -615,7 +615,7 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 	certMsg.ocspStapling = hs.clientHello.ocspStapling && len(hs.cert.OCSPStaple) > 0
 
 	hs.transcript.Write(certMsg.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, certMsg.marshal()); err != nil {
 		return err
 	}
 
@@ -647,7 +647,7 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 	certVerifyMsg.signature = sig
 
 	hs.transcript.Write(certVerifyMsg.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, certVerifyMsg.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, certVerifyMsg.marshal()); err != nil {
 		return err
 	}
 
@@ -662,7 +662,7 @@ func (hs *serverHandshakeStateTLS13) sendServerFinished() error {
 	}
 
 	hs.transcript.Write(finished.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, finished.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, finished.marshal()); err != nil {
 		return err
 	}
 
@@ -755,7 +755,7 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 	}
 	m.lifetime = uint32(maxSessionTicketLifetime / time.Second)
 
-	if _, err := c.writeRecord(recordTypeHandshake, m.marshal()); err != nil {
+	if _, err := c.WriteRecord(recordTypeHandshake, m.marshal()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
This PR exposes the WriteRecord method under tls.Conn allowing users to send custom tls payloads

## Motivation / Rationale
This allows finer control over the tls process and for detection of certain bugs like heartbleed (CVE-2014-0160)