### PR TITLE
fix: ServerHello.key_share schema definition (SubRecord misuse)

### DIFF
--- a/zcrypto_schemas/zcrypto.py
+++ b/zcrypto_schemas/zcrypto.py
@@ -661,8 +661,7 @@ ServerHello = SubRecordType({
         "raw": Binary(),
     }), doc="The values in the SignedCertificateTimestampList of the Signed Certificate Timestamp, if present."),
     "supported_versions": ServerSupportedVersions(doc="The list of supported versions in the Supported Versions extension, if present (see https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-4.2.1)."),
-    "key_share": SubRecord({
-        CurveID(doc="Negotiated TLS 1.3 key exchange group (NamedGroup/CurveID)."),}),
+    "key_share": CurveID(doc="Negotiated TLS 1.3 key exchange group (NamedGroup/CurveID)."),
     "alpn_protocol": String(doc="This contains the selected protocol from the Application-Layer Protocol Negotiation extension, if present (see https://tools.ietf.org/html/rfc7301)."),
     "extension_identifiers": ListOf(Unsigned16BitInteger(), category="Extension Identifiers", doc="The list of unparsed TLS extension identifiers in handshake."),
     "unknown_extensions": ListOf(Binary(), doc="A list of any unrecognized extensions in raw form."),


### PR DESCRIPTION
## Summary

This PR fixes the schema definition of `server_hello.key_share` in `zcrypto_schemas/zcrypto.py`.

## Technical Details
The current implementation defines it as: `"key_share": SubRecord({ CurveID(...) }),`.
However, `SubRecord(...)` expects a dictionary of named subfields. Passing a set-like literal results in a runtime error during schema import: `AttributeError: 'set' object has no attribute 'items'` (seen in https://github.com/zmap/zgrab2/pull/672 integration tests). 

This change replaces the incorrect `SubRecord(...)` usage with a direct `CurveID(...)` type: `"key_share": CurveID(...)`.

`CurveID` already represents the correct structure for TLS NamedGroup values (`hex`, `name`, `value`). Since `server_hello.key_share` is a single negotiated group, it should use `CurveID` directly instead of being wrapped in `SubRecord`.

This bug currently causes `zcrypto_schemas` to fail at import time in Python (e.g., during zgrab2 integration tests).

## Motivation

Attempt to fix the https://github.com/zmap/zgrab2/pull/672 integration tests.