### PR TITLE
fix: normalize NamedGroup string for X25519 and X448 to IANA names

### DIFF
--- a/tls/tls_names.go
+++ b/tls/tls_names.go
@@ -439,8 +439,8 @@ func init() {
 	curveNames[26] = "brainpoolP256r1"
 	curveNames[27] = "brainpoolP384r1"
 	curveNames[28] = "brainpoolP512r1"
-	curveNames[29] = "ecdh_x25519" // TEMPORARY -- expires 1Mar2018
-	curveNames[30] = "ecdh_x448"   // TEMPORARY -- expires 1Mar2018
+	curveNames[29] = "x25519"
+	curveNames[30] = "x448"
 	curveNames[256] = "ffdhe2048"
 	curveNames[257] = "ffdhe3072"
 	curveNames[258] = "ffdhe4096"


### PR DESCRIPTION
## Summary

This PR updates the string representation of CurveID 29 and 30 in `tls/tls_names.go`

- `ecdh_x25519` → `x25519`
- `ecdh_x448` → `x448`


## Technical details

`CurveID` values represent TLS NamedGroup identifiers. According to the IANA TLS NamedGroup registry and RFC 8446, the canonical names for groups 29 and 30 are:

- 29 → `x25519`
- 30 → `x448`

The previous labels (`ecdh_x25519` and `ecdh_x448`) were legacy/temporary naming conventions.

This mismatch causes downstream schema validation failures in tools (zgrab2) that validate `server_hello.key_share.name` against the standard NamedGroup enum. 

This seems to be the cause of the test integration failure in this zgrab2 PR: https://github.com/zmap/zgrab2/pull/672, where the error is: `zschema.keys.DataValidationException: name: the value ecdh_x25519 is not a valid enum option`. This PR is an attempt to fix that error. 