### PR TITLE
tls: opt-out BEAST mitigation for TLS 1.0 CBC ciphers

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -903,6 +903,18 @@ type Config struct {
 	// Client-side Only
 	ForceSuites bool
 
+	// DisableTLS10BEASTMitigation, when true, suppresses the 1/(n-1) record
+	// split applied to TLS 1.0 application_data records written over a CBC
+	// cipher. The split randomizes the implicit IV and mitigates the BEAST
+	// chosen-plaintext attack described at
+	// https://www.openssl.org/~bodo/tls-cbc.txt and
+	// https://www.imperialviolet.org/2012/01/15/beastfollowup.html.
+	//
+	// The mitigation is on by default. Set this to true only when
+	// interoperating with a TLS 1.0 peer that mishandles the resulting
+	// 1-byte record (the reason upstream crypto/tls dropped the behavior).
+	DisableTLS10BEASTMitigation bool
+
 	// Export RSA Key
 	ExportRSAKey *rsa.PrivateKey
 
@@ -1054,6 +1066,7 @@ func (c *Config) Clone() *Config {
 		ExplicitCurvePreferences:       c.ExplicitCurvePreferences,
 		SignatureAndHashes:             c.SignatureAndHashes,
 		ForceSuites:                    c.ForceSuites,
+		DisableTLS10BEASTMitigation:    c.DisableTLS10BEASTMitigation,
 		ExportRSAKey:                   c.ExportRSAKey,
 		HeartbeatEnabled:               c.HeartbeatEnabled,
 		ClientDSAEnabled:               c.ClientDSAEnabled,

--- a/tls/conn.go
+++ b/tls/conn.go
@@ -1141,8 +1141,30 @@ func (c *Conn) Write(b []byte) (int, error) {
 		return 0, errShutdown
 	}
 
+	// TLS 1.0 is susceptible to a chosen-plaintext attack when using block
+	// mode ciphers due to predictable IVs. Splitting each Application Data
+	// record into two records effectively randomizes the IV. Applied by
+	// default; opt out via Config.DisableTLS10BEASTMitigation when a TLS 1.0
+	// peer mishandles the resulting 1-byte record (see commit 4f0ea0e for
+	// the interop concern).
+	//
+	// https://www.openssl.org/~bodo/tls-cbc.txt
+	// https://bugzilla.mozilla.org/show_bug.cgi?id=665814
+	// https://www.imperialviolet.org/2012/01/15/beastfollowup.html
+	var m int
+	if len(b) > 1 && c.vers == VersionTLS10 &&
+		(c.config == nil || !c.config.DisableTLS10BEASTMitigation) {
+		if _, ok := c.out.cipher.(cipher.BlockMode); ok {
+			n, err := c.writeRecordLocked(recordTypeApplicationData, b[:1])
+			if err != nil {
+				return n, c.out.setErrorLocked(err)
+			}
+			m, b = 1, b[1:]
+		}
+	}
+
 	n, err := c.writeRecordLocked(recordTypeApplicationData, b)
-	return n, c.out.setErrorLocked(err)
+	return n + m, c.out.setErrorLocked(err)
 }
 
 // handleRenegotiation processes a HelloRequest handshake message.

--- a/tls/conn_test.go
+++ b/tls/conn_test.go
@@ -255,6 +255,122 @@ func TestDynamicRecordSizingWithTLSv13(t *testing.T) {
 	runDynamicRecordSizingTest(t, config)
 }
 
+// TestTLS10BEASTMitigation exercises the CBC record-splitting mitigation
+// restored under Config.DisableTLS10BEASTMitigation. By default Write splits
+// into a 1-byte record followed by the remainder; setting the opt-out flag
+// reverts to a single application_data record.
+func TestTLS10BEASTMitigation(t *testing.T) {
+	payload := []byte("hello BEAST")
+
+	for _, tc := range []struct {
+		name           string
+		disable        bool
+		wantAppRecords int
+		wantFirstLen   int // plaintext length carried by the first app_data record
+	}{
+		{"default_on", false, 2, 1},
+		{"opt_out", true, 1, len(payload)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serverConfig := testConfig.Clone()
+			serverConfig.MinVersion = VersionTLS10
+			serverConfig.MaxVersion = VersionTLS10
+			serverConfig.CipherSuites = []uint16{TLS_RSA_WITH_AES_128_CBC_SHA}
+			serverConfig.DisableTLS10BEASTMitigation = tc.disable
+
+			clientConfig := testConfig.Clone()
+			clientConfig.MinVersion = VersionTLS10
+			clientConfig.MaxVersion = VersionTLS10
+			clientConfig.CipherSuites = []uint16{TLS_RSA_WITH_AES_128_CBC_SHA}
+
+			clientConn, serverConn := localPipe(t)
+			tlsServer := Server(serverConn, serverConfig)
+
+			handshakeDone := make(chan struct{})
+			recordsChan := make(chan []recordObservation, 1)
+			defer func() { <-recordsChan }()
+
+			go func() {
+				defer close(recordsChan)
+				defer clientConn.Close()
+
+				tlsClient := Client(clientConn, clientConfig)
+				if err := tlsClient.Handshake(); err != nil {
+					t.Errorf("client handshake: %v", err)
+					return
+				}
+				close(handshakeDone)
+
+				// Read raw TLS records off the wire so we can count
+				// application_data records independently of what the
+				// tls.Conn.Read loop would coalesce.
+				var header [recordHeaderLen]byte
+				var observed []recordObservation
+				for {
+					_, err := io.ReadFull(clientConn, header[:])
+					if err == io.EOF || err == io.ErrUnexpectedEOF {
+						break
+					}
+					if err != nil {
+						t.Errorf("read header: %v", err)
+						return
+					}
+					length := int(header[3])<<8 | int(header[4])
+					body := make([]byte, length)
+					if _, err := io.ReadFull(clientConn, body); err != nil {
+						t.Errorf("read body: %v", err)
+						return
+					}
+					observed = append(observed, recordObservation{
+						typ:    recordType(header[0]),
+						cipher: length,
+					})
+				}
+				recordsChan <- observed
+			}()
+
+			if err := tlsServer.Handshake(); err != nil {
+				t.Fatalf("server handshake: %v", err)
+			}
+			<-handshakeDone
+
+			if _, err := tlsServer.Write(payload); err != nil {
+				t.Fatalf("server write: %v", err)
+			}
+			if err := tlsServer.Close(); err != nil {
+				t.Fatalf("server close: %v", err)
+			}
+
+			observed := <-recordsChan
+			if observed == nil {
+				t.Fatalf("client read loop failed")
+			}
+			var appRecords []recordObservation
+			for _, r := range observed {
+				if r.typ == recordTypeApplicationData {
+					appRecords = append(appRecords, r)
+				}
+			}
+			if len(appRecords) != tc.wantAppRecords {
+				t.Fatalf("got %d application_data records, want %d (all records: %+v)",
+					len(appRecords), tc.wantAppRecords, observed)
+			}
+			// For AES-128-CBC-SHA1 the ciphertext length is
+			// roundUp(plaintext + 20-byte MAC + 1 pad-length byte, 16).
+			wantFirstCipher := roundUp(tc.wantFirstLen+20+1, 16)
+			if appRecords[0].cipher != wantFirstCipher {
+				t.Fatalf("first app_data ciphertext length = %d, want %d (plaintext %d bytes)",
+					appRecords[0].cipher, wantFirstCipher, tc.wantFirstLen)
+			}
+		})
+	}
+}
+
+type recordObservation struct {
+	typ    recordType
+	cipher int // length field from the record header
+}
+
 // hairpinConn is a net.Conn that makes a “hairpin” call when closed, back into
 // the tls.Conn which is calling it.
 type hairpinConn struct {

--- a/tls/tls_test.go
+++ b/tls/tls_test.go
@@ -828,7 +828,8 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf(RenegotiateOnceAsClient))
 		case "ExplicitCurvePreferences", "ForceSuites", "HeartbeatEnabled",
 			"ClientDSAEnabled", "ExtendedRandom", "ForceSessionTicketExt",
-			"ExtendedMasterSecret", "SignedCertificateTimestampExt", "CertsOnly", "DontBufferHandshakes":
+			"ExtendedMasterSecret", "SignedCertificateTimestampExt", "CertsOnly", "DontBufferHandshakes",
+			"DisableTLS10BEASTMitigation":
 			f.Set(reflect.ValueOf(true))
 		case "ClientRandom", "ExternalClientHello":
 			f.Set(reflect.ValueOf([]byte{}))


### PR DESCRIPTION
This resurrects the 1/(n-1) record split removed in 4f0ea0e behind a new
Config.EnableTLS10BEASTMitigation flag. The mitigation randomizes the
implicit IV used by TLS 1.0 CBC ciphers, defeating the BEAST
chosen-plaintext attack described at
https://www.openssl.org/~bodo/tls-cbc.txt.

It was removed in 4f0ea0e because it caused interoperability issues with
some NTLM servers.

Leaving this vulnerability in isn't ideal, but research demands
the ability to turn it off. So the compromise is to add a new flag to
opt out of the mitigation.

Fixes #488
