### PR TITLE
Respect user ciphers on TLS1.3 and surface the SupportedVersions field from ClientHandshake

### DIFF
--- a/tls/common.go
+++ b/tls/common.go
@@ -833,11 +833,10 @@ type Config struct {
 	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
 	InsecureSkipVerify bool
 
-	// CipherSuites is a list of supported cipher suites for TLS versions up to
-	// TLS 1.2. If CipherSuites is nil, a default list of secure cipher suites
-	// is used, with a preference order based on hardware performance. The
-	// default cipher suites might change over Go versions. Note that TLS 1.3
-	// ciphersuites are not configurable.
+	// CipherSuites is a list of supported cipher suites. For TLS 1.2 and
+	// below, the order determines preference. For TLS 1.3, any TLS 1.3 suite
+	// IDs present in the list are used; if none are present (or the list is
+	// nil), a default list of secure suites is used.
 	CipherSuites []uint16
 
 	// PreferServerCipherSuites controls whether the server selects the
@@ -1234,6 +1233,14 @@ func (c *Config) cipherSuites() []uint16 {
 	s := c.CipherSuites
 	if s == nil {
 		s = defaultCipherSuites()
+	}
+	return s
+}
+
+func (c *Config) cipherSuitesTLS13() []uint16 {
+	s := c.CipherSuites
+	if s == nil {
+		s = defaultCipherSuitesTLS13()
 	}
 	return s
 }

--- a/tls/common.go
+++ b/tls/common.go
@@ -1238,11 +1238,20 @@ func (c *Config) cipherSuites() []uint16 {
 }
 
 func (c *Config) cipherSuitesTLS13() []uint16 {
-	s := c.CipherSuites
-	if s == nil {
-		s = defaultCipherSuitesTLS13()
+	if c == nil || len(c.CipherSuites) == 0 {
+		return defaultCipherSuitesTLS13()
 	}
-	return s
+	var tls13Suites []uint16
+	for _, id := range c.CipherSuites {
+		switch id {
+		case TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256:
+			tls13Suites = append(tls13Suites, id)
+		}
+	}
+	if len(tls13Suites) == 0 {
+		return defaultCipherSuitesTLS13()
+	}
+	return tls13Suites
 }
 
 var supportedVersions = []uint16{

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -312,7 +312,10 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, map[CurveID]tls13KeyShare, er
 
 	var keySharesByGroup map[CurveID]tls13KeyShare
 	if hello.supportedVersions[0] == VersionTLS13 {
-		hello.cipherSuites = append(hello.cipherSuites, config.cipherSuitesTLS13()...)
+		if !config.ForceSuites {
+			// If ForceSuites == true, we've already appended the user's ciphers above
+			hello.cipherSuites = append(hello.cipherSuites, config.cipherSuitesTLS13()...)
+		}
 
 		prefs := config.curvePreferences()
 		if len(prefs) == 0 {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -312,7 +312,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, map[CurveID]tls13KeyShare, er
 
 	var keySharesByGroup map[CurveID]tls13KeyShare
 	if hello.supportedVersions[0] == VersionTLS13 {
-		hello.cipherSuites = config.cipherSuitesTLS13()
+		hello.cipherSuites = append(hello.cipherSuites, config.cipherSuitesTLS13()...)
 
 		prefs := config.curvePreferences()
 		if len(prefs) == 0 {

--- a/tls/handshake_client.go
+++ b/tls/handshake_client.go
@@ -312,7 +312,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, map[CurveID]tls13KeyShare, er
 
 	var keySharesByGroup map[CurveID]tls13KeyShare
 	if hello.supportedVersions[0] == VersionTLS13 {
-		hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13()...)
+		hello.cipherSuites = config.cipherSuitesTLS13()
 
 		prefs := config.curvePreferences()
 		if len(prefs) == 0 {

--- a/tls/tls_handshake.go
+++ b/tls/tls_handshake.go
@@ -38,6 +38,7 @@ type ClientHello struct {
 	Scts                 bool                `json:"scts"`
 	SupportedCurves      []CurveID           `json:"supported_curves,omitempty"`
 	SupportedPoints      []PointFormat       `json:"supported_point_formats,omitempty"`
+	SupportedVersions    []TLSVersion        `json:"supported_versions,omitempty"`
 	SessionTicket        *SessionTicket      `json:"session_ticket,omitempty"`
 	SignatureAndHashes   []SignatureAndHash  `json:"signature_and_hashes,omitempty"`
 	SctEnabled           bool                `json:"sct_enabled"`
@@ -326,6 +327,12 @@ func (m *clientHelloMsg) MakeLog() *ClientHello {
 	ch.SupportedPoints = make([]PointFormat, len(m.supportedPoints))
 	for i, aFormat := range m.supportedPoints {
 		ch.SupportedPoints[i] = PointFormat(aFormat)
+	}
+	if len(m.supportedVersions) > 0 {
+		ch.SupportedVersions = make([]TLSVersion, 0, len(m.supportedVersions))
+		for _, aVersion := range m.supportedVersions {
+			ch.SupportedVersions = append(ch.SupportedVersions, TLSVersion(aVersion))
+		}
 	}
 
 	if len(m.sessionTicket) > 0 {


### PR DESCRIPTION
This PR does two things:

- If `config.ForceSuites == false`, we append the TLS 1.3 cipher suites from either the default or the user-provided list to the supported ciphers
- If `config.ForceSuites == true`, we use the user-provided list verbatim, no sanity checking
- We export the `SupportedVersions` extension added in TLS1.3 if found into the `HandshakeLog.ClientHello`. This helps us with testing visibility in ZGrab2 along with feeling like something we should expose.