### PR TITLE
Update the tls portable ciphers list

### DIFF
--- a/tls/cipher_suites.go
+++ b/tls/cipher_suites.go
@@ -1270,6 +1270,11 @@ var PortableCiphers []uint16 = []uint16{
 	TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
 	TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 	// Most of the other implemented ciphers, in a somewhat reasonable order
+	// TLSv1.3 ciphers
+	TLS_CHACHA20_POLY1305_SHA256,
+	TLS_AES_128_GCM_SHA256,
+	TLS_AES_256_GCM_SHA384,
+	// The rest ...
 	TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
 	TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 	TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,


### PR DESCRIPTION
This is for #514  

Note, as I believe was mentioned a while ago, the other collections of cipher-suites in this file (e.g. Firefox, Safari, Chrome, etc) are very possibly/probably not up to date.

I _think_ the consensus was that was OK - they're best-effort, and not necessarily relied upon by anyone who is making noise.

Regardless, I don't have the time to look into whether they're correct, otherwise I would address them. This change is just to make the portable list complete.

Thanks!